### PR TITLE
Added URL encoding functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "nix",
  "once_cell",
  "pacmanconf",
+ "percent-encoding",
  "raur",
  "raur-ext",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ htmlescape = "0.3.1"
 indicatif = "0.15.0"
 nix = "0.19.0"
 once_cell = "1.4.1"
+percent-encoding = "2.1.0"
 
 [build-dependencies]
 alpm = "1.0.0-rc1"

--- a/src/download.rs
+++ b/src/download.rs
@@ -14,10 +14,13 @@ use alpm::Version;
 use ansi_term::Style;
 use anyhow::{bail, Context, Result};
 use aur_depends::Base;
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use raur_ext::{Package, RaurExt};
 use srcinfo::Srcinfo;
 
 use indicatif::{ProgressBar, ProgressStyle};
+
+const FRAGMENT: &AsciiSet = &CONTROLS.add(b'@').add(b'+');
 
 #[derive(Debug, Clone)]
 pub struct Bases {
@@ -386,6 +389,7 @@ pub fn show_pkgbuilds(config: &mut Config) -> Result<i32> {
 
         for base in &bases.bases {
             let base = base.package_base().to_string();
+            let base = utf8_percent_encode(&base, FRAGMENT);
             let url = config
                 .aur_url
                 .join(&format!("cgit/aur.git/plain/PKGBUILD?h={}", base))?;


### PR DESCRIPTION
added the functionality to encode the `@` and `+` characters, as referenced in #8 