### PR TITLE
Fix Typo in remove make depends

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -245,7 +245,7 @@ pub fn install(config: &mut Config, targets_str: &[String]) -> Result<i32> {
 
     if remove_make {
         let mut args = config.pacman_globals();
-        args.op("remove").arg("nocnfirm");
+        args.op("remove").arg("noconfirm");
         args.targets = actions
             .iter_build_pkgs()
             .filter(|p| p.make)


### PR DESCRIPTION
Fixes a typo which caused RemoveMake to fail. 