### PR TITLE
Man page improvements

### DIFF
--- a/completions/fish
+++ b/completions/fish
@@ -175,7 +175,6 @@ complete -c $progname -n "not $noopt" -l pacman -d 'Pacman command to use' -f
 complete -c $progname -n "not $noopt" -l git -d 'Git command to use' -f
 complete -c $progname -n "not $noopt" -l gpg -d 'Gpg command to use' -f
 complete -c $progname -n "not $noopt" -l fm -d 'File manager to use' -f
-complete -c $progname -n "not $noopt" -l requestsplit -d 'Max amount of packages to query per AUR request' -f
 complete -c $progname -n "not $noopt" -l completioninterval -d 'Refresh interval for completion cache' -f
 complete -c $progname -n "not $noopt" -l sortby -d 'Sort AUR results by a specific field during search' -xa "{votes,popularity,id,baseid,name,base,submitted,modified}"
 complete -c $progname -n "not $noopt" -l searchby -d 'Search for AUR packages by querying the specified field' -xa "{name,name-desc,maintainer,depends,checkdepends,makedepends,optdepends}"

--- a/completions/zsh
+++ b/completions/zsh
@@ -31,7 +31,6 @@ _pacman_opts_common=(
 	'--config[An alternate configuration file]:config file:_files'
 	'--makepkgconf[makepkg.conf file to use]:config file:_files'
 	'--nomakepkgconf[Use the default makepkg.conf]'
-	'--requestsplitn[Max amount of packages to query per AUR request]:number'
 	'--completioninterval[Time in days to refresh completion cache]:number'
 	'--confirm[Always ask for confirmation]'
 	'--debug[Display debug messages]'

--- a/man/paru.8
+++ b/man/paru.8
@@ -364,7 +364,7 @@ another package, install all the packages in the install queue.
 Always install AUR packages immediately after building them.
 
 .TP
-.B \-\-rebuild <yes|no|all>
+.B \-\-rebuild [yes|no|all]
 Always build target packages even when a copy is available in cache. If all is
 selected then all packages are rebuilt, not only targets. Defaults to no.
 

--- a/man/paru.8
+++ b/man/paru.8
@@ -1,9 +1,9 @@
 '\ t
-.TH "PARU" "8" "2019\-10\-21" "paru v0.0.1" "Paru  Manual"
+.TH "PARU" "8" "2020\-10\-28" "paru v1.0.0" "Paru Manual"
 .nh
 .ad l
 .SH NAME
-PARU \- AUR Helper
+PARU \- An AUR helper and pacman wrapper
 
 .SH SYNOPSIS
 \fIparu\fR <operation> [options] [targets]
@@ -13,7 +13,8 @@ PARU \- AUR Helper
 \fIparu\fR
 
 .SH DESCRIPTION
-Paru is an AUR helper and pacman wrapper.
+Paru is an AUR helper written in Rust and based on the design of yay. It aims
+to be your standard pacman wrapping AUR helper with minimal interaction.
 
 Paru is a tool to easily build and install packages from the AUR, along with
 their dependencies. Paru also expands many of pacman's options making them
@@ -31,7 +32,7 @@ Printing related options.
 
 .TP
 .B \-G, \-\-getpkgbuild
-Downloads PKGBUILD from ABS or AUR. The ABS can only be used for Arch Linux
+Downloads PKGBUILDs from ABS or AUR. The ABS can only be used for Arch Linux
 repositories
 
 .RE
@@ -48,10 +49,9 @@ Paru will also remove cached data about devel packages.
 
 .TP
 .B \-Sc
-Paru will also clean cached AUR package and any untracked Files in the
+Paru will also clean cached AUR packages and any untracked files in the
 cache. Cleaning untracked files will wipe any downloaded sources or
-built packages but will keep already downloaded vcs sources.
-
+built packages but will keep already downloaded VCS sources.
 
 .TP
 .B \-S, \-Si, \-Sl, \-Ss, \-Su, \-Qu
@@ -66,13 +66,13 @@ terms and prompts the user on which packages to install.
 
 .TP
 .B \-\-gendb
-Generate development package database. Tracks the latest commit for each
-development package, when there is a new commit paru will know to update. This
-is done per package whenever a package is synced. This option should only be
-used when migrating to paru from another AUR helper.
+Generate the development package database. This tracks the latest commit for
+each development package, so when there is a new commit paru will know to
+update. This is done per package whenever a package is synced. This option
+should only be used when migrating to paru from another AUR helper.
 
-This also causes paru to assume all current development packages are up to date.
-Updates will then be detected on the next commit.
+This also causes paru to assume all current development packages are up to
+date. Updates will then be detected on the next commit.
 
 .TP
 .B \-c, \-\-clean
@@ -89,26 +89,24 @@ and is not intended to be used directly by the user.
 
 .TP
 .B \-w, \-\-news
-Print new news from the Archlinux homepage. News is considered new if it is
+Print new news from the Arch Linux homepage. News is considered new if it is
 newer than the build date of all native packages. Pass this twice to show all
 available news.
 
 .SH GETPKGBUILD OPTIONS (APPLY TO \-G AND \-\-GETPKGBUILD)
 .TP
-
-.TP
 .B \-p, \-\-print
-Prints the pkgbuild to the terminal instead of downloading it.
+Prints the PKGBUILD to the terminal instead of downloading it.
 
 .SH NEW OPTIONS
 .TP
-.B    \-\-repo
-Assume all targets are from the repositories. Additionally Actions such as
+.B \-\-repo
+Assume all targets are from the repositories. Additionally, actions such as
 sysupgrade will only act on repository packages.
 
 .TP
 .B \-a, \-\-aur
-Assume all targets are from the AUR. Additionally Actions such as
+Assume all targets are from the AUR. Additionally, actions such as
 sysupgrade will only act on AUR packages.
 
 Note that dependency resolving will still act normally and include repository
@@ -121,7 +119,7 @@ to use https://aur.tuna.tsinghua.edu.cn/.
 
 .TP
 .B \-\-builddir <dir>
-Directory to use for Building AUR Packages. This directory is also used as
+Directory to use for building AUR Packages. This directory is also used as
 the AUR cache when deciding if paru should skip builds.
 
 .TP
@@ -144,7 +142,7 @@ The command to use for \fBgit\fR calls. This can be a command in
 Passes arguments to git. These flags get passed to every instance where
 git is called by paru. Arguments are split on whitespace before being
 passed to git. Multiple arguments may be passed by supplying a space
-separated list that is quoted by the shell
+separated list that is quoted by the shell.
 
 .TP
 .B \-\-gpg <command>
@@ -158,8 +156,9 @@ gpg is called by paru. Arguments are split on whitespace before being
 passed to gpg. Multiple arguments may be passed by supplying a space
 separated list that is quoted by the shell.
 
+.TP
 .B \-\-fm <command>
-This enables fm review mode, where pkgbuild review is done using the file
+This enables fm review mode, where PKGBUILD review is done using the file
 manager specified by command.
 
 .TP
@@ -184,8 +183,8 @@ separated list that is quoted by the shell.
 .TP
 .B \-\-sudo <command>
 The command to use for \fBsudo\fR calls. This can be a command in
-\fBPATH\fR or an absolute path to the file.
-The sudoloop is not guaranteed to work with a custom \fBsudo\fR command.
+\fBPATH\fR or an absolute path to the file. The --sudoloop option is not
+guaranteed to work with a custom \fBsudo\fR command.
 
 .TP
 .B \-\-sudoflags <flags>
@@ -198,31 +197,31 @@ separated list that is quoted by the shell.
 .B \-\-completioninterval <days>
 Time in days to refresh the completion cache. Setting this to 0 will cause
 the cache to be refreshed every time, while setting this to -1 will cause the
-cache to never be refreshed.
+cache to never be refreshed. Defaults to 7.
 
 .TP
 .B \-\-requestsplitn <number>
 The maximum amount of packages to request per AUR query. The higher the
 number the faster AUR requests will be. Requesting too many packages in one
 AUR query will cause an error. This should only make a noticeable difference
-with very large requests (>500) packages.
+with very large requests (>500) packages. Defaults to 150.
 
 .TP
 .B \-\-sortby <votes|popularity|id|baseid|name|base|submitted|modified>
-Sort AUR results by a specific field during search.
+Sort AUR results by a specific field during search. Defaults to votes.
 
 .TP
 .B \-\-searchby <name|name-desc|maintainer|depends|checkdepends|makedepends|optdepends>
-Search for AUR packages by querying the specified field.
+Search for AUR packages by querying the specified field. Defaults to name-desc.
 
 .TP
 .B \-\-upgrademenu
-Show a detailed list of updates in a similar format to VerbosePkgLists.
-Upgrades can also be skipped using numbers, number ranges or repo names.
-Additionally ^ can be used to invert the selection.
+Show a detailed list of updates in a similar format to 
+VerbosePkgLists. Upgrades can also be skipped using numbers, number ranges or
+repo names. Additionally ^ can be used to invert the selection.
 
 Additionally an argument can be passed to this flag and the menu will use
-this input instead of reafing from stdin.
+this input instead of reading from stdin.
 
 \fBWarning\fR: It is not recommended to skip updates from the repositories as
 this can lead to partial upgrades. This feature is intended to easily skip AUR
@@ -234,19 +233,21 @@ it is up to the user what upgrades they skip.
 Do not show the upgrade menu.
 
 .TP
-.B \-\-removemake [yes|no|ask]
-Remove makedepends after installing packages. Defaults to yes.
+.B \-\-removemake <yes|no|ask>
+Remove makedepends after installing packages. Defaults to no.
 
-.B \-\-noremovemake [yes|no|ask]
+.TP
+.B \-\-noremovemake
 Don't remove makedepends after installing packages.
 
 .TP
 .B \-\-topdown
-Print search results from top to bottom.
+Print search results from top to bottom. Repo packages will print first. This
+is the default.
 
 .TP
 .B \-\-bottomup
-Print search results from bottom to top.
+Print search results from bottom to top. AUR packages will print first.
 
 .TP
 .B \-\-nocheck
@@ -267,7 +268,7 @@ only Git packages are supported.
 
 Devel checking is done using \fBgit ls-remote\fR. The newest commit hash is
 compared against the hash at install time. This allows devel updates to be
-checked almost instantly and not require the original pkgbuild to be downloaded.
+checked almost instantly and not require the original PKGBUILD to be downloaded.
 
 The slower pacaur-like devel checks can be implemented manually by piping
 a list of packages into paru (see \fBexamples\fR).
@@ -282,31 +283,25 @@ Suffixes that paru will use to decide if a package is a devel package.
 Used when determining if a pkgver bump is used when the --needed option is
 set.
 
-
-
-
-
-
 .TP
 .B \-\-cleanafter
 Remove untracked files after installation.
 
-Untracked files are removed with the exception of directories.
-This allows VCS packages to easily pull an update
-instead of having to reclone the entire repo.
+Untracked files are removed with the exception of directories. This allows VCS
+packages to easily pull an update instead of having to reclone the entire repo.
 
 .TP
 .B \-\-nocleanafter
-Do not remove package sources after successful Install.
+Do not remove package sources after successful install.
 
 .TP
-.B \-\-redownload [yes|no|all]
-Always download pkgbuilds of targets even when a copy is available in cache.
-If all is used then this applies to all packages, not only targets.
+.B \-\-redownload <yes|no|all>
+Always download PKGBUILDS of targets even when a copy is available in cache. If
+all is used then this applies to all packages, not only targets. Defaults to no.
 
 .TP
 .B \-\-noredownload
-When downloading pkgbuilds if the pkgbuild is found in cache and is equal or
+When downloading PKGBUILDs, if the PKGBUILD is found in cache and is equal or
 newer than the AUR's version use that instead of downloading a new one.
 
 .TP
@@ -317,9 +312,9 @@ increases dependency resolve time although this should not be noticeable.
 
 .TP
 .B \-\-noprovides
-Do not look for matching providers when searching for AUR packages.
-paru will never show its provider menu but Pacman will still show its
-provider menu for repo packages.
+Do not look for matching providers when searching for AUR packages. Paru will
+never show its provider menu but pacman will still show its provider menu for
+repo packages.
 
 .TP
 .B \-\-pgpfetch
@@ -334,10 +329,10 @@ gpg config\%.
 
 .TP
 .B \-\-useask
-Use pacman's --ask flag to automatically confirm package conflicts. paru lists
-conflicts ahead of time. It is possible that paru does not detect
-a conflict, causing a package to be removed without the user's confirmation.
-However, this is very unlikely.
+Use pacman's --ask flag to automatically confirm package conflicts. Paru lists
+conflicts ahead of time. It is possible that paru does not detect a conflict, 
+causing a package to be removed without the user's confirmation. However, this
+is very unlikely.
 
 .TP
 .B \-\-nouseask
@@ -348,17 +343,17 @@ conflict will not need to be confined manually.
 .B \-\-combinedupgrade
 During sysupgrade, paru will first perform a refresh, then show
 its combined menu of repo and AUR packages that will be upgraded. Then after
-reviewing the pkgbuilds, the repo and AUR upgrade will start with no need
+reviewing the PKGBUILDs, the repo and AUR upgrade will start with no need
 for manual intervention.
 
-If paru exits for any reason After the refresh without upgrading. It is then
+If paru exits for any reason after the refresh without upgrading, it will be
 the user's responsibility to either resolve the reason paru exited or run
 a sysupgrade through pacman directly.
 
 .TP
 .B \-\-nocombinedupgrade
-During sysupgrade, Pacman \-Syu will be called, then the AUR upgrade will
-start. This means the upgrade menu and pkgbuild review will be performed
+During sysupgrade, pacman \-Syu will be called, then the AUR upgrade will
+start. This means the upgrade menu and PKGBUILD review will be performed
 after the sysupgrade has finished.
 
 .TP
@@ -373,9 +368,9 @@ another package, install all the packages in the install queue.
 Always install AUR packages immediately after building them.
 
 .TP
-.B \-\-rebuild [yes|no|all]
-Always build target packages even when a copy is available in cache.
-If all is selected then all packages are rebuilt, not only targets.
+.B \-\-rebuild <yes|no|all>
+Always build target packages even when a copy is available in cache. If all is
+selected then all packages are rebuilt, not only targets. Defaults to no.
 
 .TP
 .B \-\-norebuild
@@ -384,8 +379,8 @@ to the one wanted skip the package build and use the existing package.
 
 .TP
 .B \-\-sudoloop
-Loop sudo calls in the background to prevent sudo from timing out during long
-builds.
+Periodically call sudo in the background during builds to prevent it from
+timing out.
 
 .TP
 .B \-\-nosudoloop
@@ -394,11 +389,13 @@ Do not loop sudo calls in the background.
 .SH EXAMPLES
 .TP
 paru \fIfoo\fR
-Search and install from the repos and the \fBAUR\fR\ using interactive search and install.
+Search and install from the repos and the \fBAUR\fR\ using interactive search
+and install.
 
 .TP
 paru \-Syu
-Update package list and upgrade all currently installed repo and \fBAUR\fR.
+Update package list and upgrade all currently installed repo and \fBAUR\fR
+packages.
 
 .TP
 paru \-Sua
@@ -442,9 +439,9 @@ The config directory is \fI$XDG_CONFIG_HOME/paru/\fR. If
 \fB$XDG_CONFIG_HOME\fR is unset, the config directory will fall back to
 \fI$HOME/.config/paru\fR.
 
-\fIparu.conf\fR Is used to store all of paru's config options. See
-\fBpacman(8)\fR for more about this file.
-
+\fIparu.conf\fR is used to store all of paru's config options. See
+.BR paru.conf (5)
+for more about this file.
 
 .TP
 .B CACHE DIRECTORY
@@ -452,8 +449,8 @@ The cache directory is \fI$XDG_CACHE_HOME/paru/\fR. If
 \fB$XDG_CACHE_HOME\fR is unset, the cache directory will fall back to
 \fI$HOME/.cache/paru\fR.
 
-\fIcompletion.aur\fR holds a list of of all AUR packages for shell completion.
-By default the completion files are refreshed every 7 days.
+\fIcompletion.aur\fR holds a list of of all AUR packages for shell
+completion. By default the completion files are refreshed every 7 days.
 
 \fIdevel.json\fR tracks VCS packages and the latest commit of each source. If
 any of these commits change the package will be upgraded during a devel update.
@@ -466,7 +463,7 @@ and built packages from those packages.
 
 .TP
 .B PACMAN.CONF
-Paru uses Pacman's config file to set certain pacman options either through
+Paru uses pacman's config file to set certain pacman options either through
 go\-alpm or paru itself. Options inherited include most libalpm options and
 pacman options.
 
@@ -480,7 +477,8 @@ Notably: \fBDatabases\fR, \fBColor\fR and \fB*Path/*Dir\fR options are used.
 .BR pacman (8),
 .BR pacman.conf (5)
 
-See the arch wiki at https://wiki.archlinux.org/index.php/Arch_User_Repository for more info on the \fBAUR\fR.
+See the arch wiki at https://wiki.archlinux.org/index.php/Arch_User_Repository
+for more info on the \fBAUR\fR.
 
 .SH BUGS
 Please report bugs to our GitHub page \fBhttps://github.com/Morganamilo/paru\fR

--- a/man/paru.8
+++ b/man/paru.8
@@ -193,11 +193,10 @@ passed to sudo. Multiple arguments may be passed by supplying a space
 separated list that is quoted by the shell.
 
 .TP
-.B \-\-requestsplitn <number>
-The maximum amount of packages to request per AUR query. The higher the
-number the faster AUR requests will be. Requesting too many packages in one
-AUR query will cause an error. This should only make a noticeable difference
-with very large requests (>500) packages. Defaults to 150.
+.B \-\-completioninterval <days>
+Time in days to refresh the completion cache. Setting this to 0 will cause the
+cache to be refreshed every time, while setting this to -1 will cause the cache
+to never be refreshed. Defaults to 7.
 
 .TP
 .B \-\-sortby <votes|popularity|id|baseid|name|base|submitted|modified>

--- a/man/paru.8
+++ b/man/paru.8
@@ -3,7 +3,7 @@
 .nh
 .ad l
 .SH NAME
-PARU \- An AUR helper and pacman wrapper
+paru \- AUR helper and pacman wrapper
 
 .SH SYNOPSIS
 \fIparu\fR <operation> [options] [targets]
@@ -208,12 +208,11 @@ Search for AUR packages by querying the specified field. Defaults to name-desc.
 
 .TP
 .B \-\-upgrademenu
-Show a detailed list of updates in a similar format to 
-VerbosePkgLists. Upgrades can also be skipped using numbers, number ranges or
-repo names.
-
-Additionally an argument can be passed to this flag and the menu will use
-this input instead of reading from stdin.
+Show a detailed list of updates in a similar format to pacman's VerbosePkgLists
+option. (See 
+.BR pacman.conf(5)).
+Upgrades can be skipped using numbers, number ranges, or repo
+names.
 
 \fBWarning\fR: It is not recommended to skip updates from the repositories as
 this can lead to partial upgrades. This feature is intended to easily skip AUR
@@ -289,7 +288,7 @@ packages to easily pull an update instead of having to reclone the entire repo.
 Do not remove package sources after successful install.
 
 .TP
-.B \-\-redownload [yes|no]
+.B \-\-redownload [yes|no|all]
 Always download PKGBUILDs of targets even when a copy is available in
 cache. If all is specified, then PKGBUILDs will be downloaded for all packages,
 not just targets. Defaults to yes when specified.

--- a/man/paru.8
+++ b/man/paru.8
@@ -32,8 +32,8 @@ Printing related options.
 
 .TP
 .B \-G, \-\-getpkgbuild
-Downloads PKGBUILDs from ABS or AUR. The ABS can only be used for Arch Linux
-repositories
+Downloads PKGBUILDs from the ABS or AUR. The ABS can only be used for Arch
+Linux repositories.
 
 .RE
 If no arguments are provided 'paru \-Syu' will be performed.
@@ -194,12 +194,6 @@ passed to sudo. Multiple arguments may be passed by supplying a space
 separated list that is quoted by the shell.
 
 .TP
-.B \-\-completioninterval <days>
-Time in days to refresh the completion cache. Setting this to 0 will cause
-the cache to be refreshed every time, while setting this to -1 will cause the
-cache to never be refreshed. Defaults to 7.
-
-.TP
 .B \-\-requestsplitn <number>
 The maximum amount of packages to request per AUR query. The higher the
 number the faster AUR requests will be. Requesting too many packages in one
@@ -218,7 +212,7 @@ Search for AUR packages by querying the specified field. Defaults to name-desc.
 .B \-\-upgrademenu
 Show a detailed list of updates in a similar format to 
 VerbosePkgLists. Upgrades can also be skipped using numbers, number ranges or
-repo names. Additionally ^ can be used to invert the selection.
+repo names.
 
 Additionally an argument can be passed to this flag and the menu will use
 this input instead of reading from stdin.
@@ -233,8 +227,10 @@ it is up to the user what upgrades they skip.
 Do not show the upgrade menu.
 
 .TP
-.B \-\-removemake <yes|no|ask>
-Remove makedepends after installing packages. Defaults to no.
+.B \-\-removemake [yes|no|ask]
+Remove makedepends after installing packages. If set to ask, a menu will appear
+during builds allowing an option to be chosen then. Defaults to yes when
+specified without an option.
 
 .TP
 .B \-\-noremovemake
@@ -295,9 +291,10 @@ packages to easily pull an update instead of having to reclone the entire repo.
 Do not remove package sources after successful install.
 
 .TP
-.B \-\-redownload <yes|no|all>
-Always download PKGBUILDS of targets even when a copy is available in cache. If
-all is used then this applies to all packages, not only targets. Defaults to no.
+.B \-\-redownload [yes|no]
+Always download PKGBUILDs of targets even when a copy is available in
+cache. If all is specified, then PKGBUILDs will be downloaded for all packages,
+not just targets. Defaults to yes when specified.
 
 .TP
 .B \-\-noredownload
@@ -379,8 +376,8 @@ to the one wanted skip the package build and use the existing package.
 
 .TP
 .B \-\-sudoloop
-Periodically call sudo in the background during builds to prevent it from
-timing out.
+Periodically call sudo in the background to prevent it from timing out during
+long builds.
 
 .TP
 .B \-\-nosudoloop
@@ -464,7 +461,7 @@ and built packages from those packages.
 .TP
 .B PACMAN.CONF
 Paru uses pacman's config file to set certain pacman options either through
-go\-alpm or paru itself. Options inherited include most libalpm options and
+alpm.rs or paru itself. Options inherited include most libalpm options and
 pacman options.
 
 Notably: \fBDatabases\fR, \fBColor\fR and \fB*Path/*Dir\fR options are used.

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -6,7 +6,7 @@
 paru.conf \- paru configuration file
 
 .SH SYNOPSIS
-/etc/paru.conf, $PARU_CONF, $XDG_CONFIG_HOME/paru/paru.conf, $HOME/.config/paru/paru.conf
+$PARU_CONF, $XDG_CONFIG_HOME/paru/paru.conf, $HOME/.config/paru/paru.conf, /etc/paru.conf
 
 .SH DESCRIPTION
 Paru's config file. Based on the format used by 

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -158,14 +158,13 @@ visible here: https://aur.archlinux.org/packages/
 .TP
 .B SearchBy = <name|name-desc|maintainer|depends|checkdepends|makedepends|optdepends>
 Defaults to name-desc. Search AUR packages according to the options in 
-"Search by" visible here: https://aur.archlinux.org/packages/    
+"Search by" visible here: https://aur.archlinux.org/packages/
 
 .TP
-.B RequestSplit = Number
-The maximum amount of packages to request per AUR query. The higher the
-number the faster AUR requests will be. Requesting too many packages in one
-AUR query will cause an error. This should only make a noticeable difference
-with very large requests (>500) packages. Defaults to 150.
+.B CompletionInterval = N
+Time in days to refresh the completion cache. Setting this to 0 will cause the
+cache to be refreshed every time, while setting this to -1 will cause the cache
+to never be refreshed. Defaults to 7.
 
 .TP
 .B PacmanConf = path/to/pacman.conf

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -1,39 +1,41 @@
 '\ t
-.TH "PARU.CONF" "5" "2019\-10\-21" "paru v0.0.1" "Paru  Manual"
+.TH "PARU.CONF" "5" "2020\-10\-28" "paru v1.0.0" "Paru Manual"
 .nh
 .ad l
 .SH NAME
-PARU \- AUR Helper
+paru.conf \- paru configuration file
 
 .SH SYNOPSIS
-/etc/paru.conf
-.sp
-~/.config/paru/paru.conf
+$XDG_CONFIG_HOME/paru/paru.conf, $HOME/.config/paru/paru.conf, /etc/paru.conf
 
 .SH DESCRIPTION
-Paru's config file. Based on the format used by \fBpacman.conf (5)\fR.
+Paru's config file. Based on the format used by 
+.BR pacman.conf (5)
 
-Paru will attempt to read the config file from the user's home directory. If that does not exist
-paru will instead attempt to read the file from the system config directory.
+Paru will attempt to read the config file from $XDG_CONFIG_HOME/paru/paru.conf. If
+$XDG_CONFIG_HOME is unset, it will attempt to read the file from 
+$HOME/.config/paru/paru.conf. If neither of those exist, it will read from the
+defaults at /etc/paru.conf.
 
-Aditionally the \fBInclude\fB directive can be used to copy paste files into the config. This could be used
-to extend the system config by including it in your user's config and then defining options.
+Aditionally, the \fBInclude\fB directive can be used to copy paste files into
+the config. This could be used to extend the system config by including it in
+your user's config and then defining options.
 
 .SH OPTIONS
-
 Options belonging to the [options] section.
 
 .TP
 .B TopDown
-Print search results from top to bottom.
+Print search results from top to bottom. Repo results will be printed
+first. This is the default.
 
 .TP
 .B BottomUp
-Print search results from bottom to top.
+Print search results from bottom to top. AUR results will be printed first.
 
 .TP
 .B AurOnly
-Assume all targets are from the AUR. Additionally Actions such as
+Assume all targets are from the AUR. Additionally, actions such as
 sysupgrade will only act on AUR packages.
 
 Note that dependency resolving will still act normally and include repository
@@ -41,13 +43,13 @@ packages.
 
 .TP
 .B RepoOnly
-Assume all targets are from the repositories. Additionally Actions such as
+Assume all targets are from the repositories. Additionally, actions such as
 sysupgrade will only act on repository packages.
 
 .TP
 .B SudoLoop
-Loop sudo calls in the background to prevent sudo from timing out during long
-builds.
+Periodically call sudo in the background during builds to prevent it from
+timing out.
 
 .TP
 .B NoCheck
@@ -89,49 +91,48 @@ PKGBUILD.
 .B CombinedUpgrade
 During sysupgrade, paru will first perform a refresh, then show
 its combined menu of repo and AUR packages that will be upgraded. Then after
-reviewing the pkgbuilds, the repo and AUR upgrade will start with no need
+reviewing the PKGBUILDs, the repo and AUR upgrade will start with no need
 for manual intervention.
 
-If paru exits for any reason After the refresh without upgrading. It is then
+If paru exits for any reason after the refresh without upgrading, it will be
 the user's responsibility to either resolve the reason paru exited or run
 a sysupgrade through pacman directly.
 
 .TP
 .B BatchInstall
-When building and installing AUR packages instead of installing each package
+When building and installing AUR packages; instead of installing each package
 after building, queue each package for install. Then once either all packages
 are built or a package in the build queue is needed as a dependency to build
 another package, install all the packages in the install queue.
 
 .TP
 .B UseAsk
-Use pacman's --ask flag to automatically confirm package conflicts. paru lists
+Use pacman's --ask flag to automatically confirm package conflicts. Paru lists
 conflicts ahead of time. It is possible that paru does not detect
 a conflict, causing a package to be removed without the user's confirmation.
 However, this is very unlikely.
 
 .TP
-.B Redownload [= All]
-Always download pkgbuilds of targets even when a copy is available in cache.
-If all is used then this applies to all packages, not only targets.
+.B Redownload = no | all
+Always download PKGBUILDs of targets even when a copy is available in cache. If
+set to all then this applies to all packages, not only targets. Defaults to no.
 
 .TP
-.B Rebuild [= All]
-Always build target packages even when a copy is available in cache.
-If all is selected then all packages are rebuilt, not only targets.
+.B Rebuild = no | all
+Always build target packages even when a copy is available in cache. If all is
+selected then all packages are rebuilt, not only targets. Defaults to no.
 
 .TP
-.B RemoveMake [= Ask]
-Remove makedepends after installing packages. Defaults to yes.
+.B RemoveMake = yes | no | ask
+Remove makedepends after installing packages. Defaults to no.
 
 .TP
 .B UpgradeMenu
-Show a detailed list of updates in a similar format to VerbosePkgLists.
-Upgrades can also be skipped using numbers, number ranges or repo names.
-Additionally ^ can be used to invert the selection.
-
-Additionally an argument can be passed to this flag and the menu will use
-this input instead of reafing from stdin.
+Show a detailed list of updates in a similar format to pacman's VerbosePkgLists
+option. (See 
+.BR pacman.conf(5)).
+Upgrades can be skipped using numbers, number ranges, or repo
+names. Additionally, ^ can be used to invert the selection.
 
 \fBWarning\fR: It is not recommended to skip updates from the repositories as
 this can lead to partial upgrades. This feature is intended to easily skip AUR
@@ -145,27 +146,31 @@ to use https://aur.tuna.tsinghua.edu.cn/.
 
 .TP
 .B BuildDir = /path/to/dir
-Directory to use for Building AUR Packages. This directory is also used as
+Directory to use for building AUR Packages. This directory is also used as
 the AUR cache when deciding if paru should skip builds.
 
 .TP
-.B SortBy = Votes|Popularity|Id|Baseid|Name|Base|Submitted|Modified
+.B SortBy = votes|popularity|name|base|submitted|modified|id|baseid
+Defaults to votes. Sort AUR results according to the options in "Sort by"
+visible here: https://aur.archlinux.org/packages/
 
 .TP
-.B SearchBy = name|name-desc|maintainer|depends|checkdepends|makedepends|optdepends>
+.B SearchBy = name|name-desc|maintainer|depends|checkdepends|makedepends|optdepends
+Defaults to name-desc. Search AUR packages according to the options in 
+"Search by" visible here: https://aur.archlinux.org/packages/    
 
 .TP
-.B CompletionInterval = N
+.B CompletionInterval = Number
 Time in days to refresh the completion cache. Setting this to 0 will cause
 the cache to be refreshed every time, while setting this to -1 will cause the
-cache to never be refreshed.
+cache to never be refreshed. Defaults to 7.
 
 .TP
 .B RequestSplit = Number
 The maximum amount of packages to request per AUR query. The higher the
 number the faster AUR requests will be. Requesting too many packages in one
 AUR query will cause an error. This should only make a noticeable difference
-with very large requests (>500) packages.
+with very large requests (>500) packages. Defaults to 150.
 
 .TP
 .B PacmanConf = path/to/pacman.conf
@@ -178,11 +183,10 @@ Used when determining if a pkgver bump is used when the --needed option is
 set.
 
 .TP
-.B NoWarn  = Packages...
+.B NoWarn = Packages...
 Don't warn when these packages are not in the aur, out of date, or orphaned.
 
 .SH BIN
-
 Options belonging to the [bin] section.
 
 .TP
@@ -208,13 +212,13 @@ The command to use for \fBasp\fR calls. This can be a command in
 .TP
 .B Sudo = path/to/sudo
 The command to use for \fBsudo\fR calls. This can be a command in
-\fBPATH\fR or an absolute path to the file.
-The sudoloop is not guaranteed to work with a custom \fBsudo\fR command.
+\fBPATH\fR or an absolute path to the file. The SudoLoop option is not
+guaranteed to work with a custom \fBsudo\fR command.
 
 .TP
 .B FileManager = path/to/fm
 This enables fm review mode, where pkgbuild review is done using the file
-manager specified by command.
+manager specified here.
 
 .TP
 .B MFlags = Flags...
@@ -242,6 +246,6 @@ passed to sudo.
 
 .TP
 .B FileManagerFlags = Flags...
-Passes arguments to file manager. These flags get passed to every instance where
-file manager is called by paru. Arguments are split on whitespace before being
-passed to file manager.
+Passes arguments to the file manager. These flags get passed to every instance
+where file manager is called by paru. Arguments are split on whitespace before
+being passed to file manager.

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -6,16 +6,16 @@
 paru.conf \- paru configuration file
 
 .SH SYNOPSIS
-$XDG_CONFIG_HOME/paru/paru.conf, $HOME/.config/paru/paru.conf, /etc/paru.conf
+/etc/paru.conf, $XDG_CONFIG_HOME/paru/paru.conf, $HOME/.config/paru/paru.conf
 
 .SH DESCRIPTION
 Paru's config file. Based on the format used by 
 .BR pacman.conf (5)
 
 Paru will attempt to read the config file from $XDG_CONFIG_HOME/paru/paru.conf. If
-$XDG_CONFIG_HOME is unset, it will attempt to read the file from 
-$HOME/.config/paru/paru.conf. If neither of those exist, it will read from the
-defaults at /etc/paru.conf.
+$XDG_CONFIG_HOME is not set, it will attempt to read the file from 
+$HOME/.config/paru/paru.conf. If neither of those exist, it will read from 
+/etc/paru.conf.
 
 Aditionally, the \fBInclude\fB directive can be used to copy paste files into
 the config. This could be used to extend the system config by including it in
@@ -48,8 +48,8 @@ sysupgrade will only act on repository packages.
 
 .TP
 .B SudoLoop
-Periodically call sudo in the background during builds to prevent it from
-timing out.
+Periodically call sudo in the background to prevent it from timing out during
+long builds.
 
 .TP
 .B NoCheck
@@ -113,18 +113,19 @@ a conflict, causing a package to be removed without the user's confirmation.
 However, this is very unlikely.
 
 .TP
-.B Redownload = no | all
+.B Redownload [= all]
 Always download PKGBUILDs of targets even when a copy is available in cache. If
-set to all then this applies to all packages, not only targets. Defaults to no.
+set to all then this applies to all packages, not only targets.
 
 .TP
-.B Rebuild = no | all
-Always build target packages even when a copy is available in cache. If all is
-selected then all packages are rebuilt, not only targets. Defaults to no.
+.B Rebuild [= all]
+Always build target packages even when a copy is available in cache. If set to
+all, then all packages are rebuilt, not only targets.
 
 .TP
-.B RemoveMake = yes | no | ask
-Remove makedepends after installing packages. Defaults to no.
+.B RemoveMake [= ask]
+Remove makedepends after installing packages. If set to ask, a menu will appear
+during builds allowing an option to be chosen then.
 
 .TP
 .B UpgradeMenu
@@ -132,7 +133,7 @@ Show a detailed list of updates in a similar format to pacman's VerbosePkgLists
 option. (See 
 .BR pacman.conf(5)).
 Upgrades can be skipped using numbers, number ranges, or repo
-names. Additionally, ^ can be used to invert the selection.
+names.
 
 \fBWarning\fR: It is not recommended to skip updates from the repositories as
 this can lead to partial upgrades. This feature is intended to easily skip AUR
@@ -150,20 +151,14 @@ Directory to use for building AUR Packages. This directory is also used as
 the AUR cache when deciding if paru should skip builds.
 
 .TP
-.B SortBy = votes|popularity|name|base|submitted|modified|id|baseid
+.B SortBy = <votes|popularity|name|base|submitted|modified|id|baseid>
 Defaults to votes. Sort AUR results according to the options in "Sort by"
 visible here: https://aur.archlinux.org/packages/
 
 .TP
-.B SearchBy = name|name-desc|maintainer|depends|checkdepends|makedepends|optdepends
+.B SearchBy = <name|name-desc|maintainer|depends|checkdepends|makedepends|optdepends>
 Defaults to name-desc. Search AUR packages according to the options in 
 "Search by" visible here: https://aur.archlinux.org/packages/    
-
-.TP
-.B CompletionInterval = Number
-Time in days to refresh the completion cache. Setting this to 0 will cause
-the cache to be refreshed every time, while setting this to -1 will cause the
-cache to never be refreshed. Defaults to 7.
 
 .TP
 .B RequestSplit = Number

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -6,16 +6,17 @@
 paru.conf \- paru configuration file
 
 .SH SYNOPSIS
-/etc/paru.conf, $XDG_CONFIG_HOME/paru/paru.conf, $HOME/.config/paru/paru.conf
+/etc/paru.conf, $PARU_CONF, $XDG_CONFIG_HOME/paru/paru.conf, $HOME/.config/paru/paru.conf
 
 .SH DESCRIPTION
 Paru's config file. Based on the format used by 
 .BR pacman.conf (5)
 
-Paru will attempt to read the config file from $XDG_CONFIG_HOME/paru/paru.conf. If
-$XDG_CONFIG_HOME is not set, it will attempt to read the file from 
-$HOME/.config/paru/paru.conf. If neither of those exist, it will read from 
-/etc/paru.conf.
+Paru first attempts to read the file at $PARU_CONF. If $PARU_CONF is not
+set, paru attempts to read from $XDG_CONFIG_HOME/paru/paru.conf. If
+$XDG_CONFIG_HOME is not set, or the file doesn't exist, paru attempts to read
+from $HOME/.config/paru/paru.conf. If that file doesn't exist, it will read
+the system config from /etc/paru.conf.
 
 Aditionally, the \fBInclude\fB directive can be used to copy paste files into
 the config. This could be used to extend the system config by including it in


### PR DESCRIPTION
I went through the man pages after noticing that paru.conf(5) said the arguments for a few options (e.g. Redownload, Rebuild) didn't work when entered the way they appear in the man page. I found some typos, capitalization issues and formatting errors and fixed those (hopefully I caught them all). I made quite a few other changes that I think better explain some of the options too. I also tried to bring consistency to a lot of the terms (like AUR, PKGBUILD, pacman, paru). I also changed all the lines that ended in a period because man adds two spaces when that's entered.

Two things I noticed that should stay updated are the headers (at line 2) that should be kept up to date with the release version and the last time the man page was changed. Also, on line 467 of paru.8, there's a mention of go-alpm which I'm guessing is left over from the yay docs. I'm not sure what that should be changed to, if there's an equivalent Rust crate or it was integrated into paru.

Anyway if I got anything wrong or if there's any more I can do, just let me know.