### PR TITLE
install.rs: Fix not compatible with some editors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,7 @@ dependencies = [
  "serde_json",
  "smart-default",
  "srcinfo",
+ "tempfile",
  "term_size",
  "tokio",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ rss = { version = "1.9.0", default-features = false }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"
 smart-default = "0.6.0"
+tempfile = "3.1.0"
 term_size = "0.3.2"
 tokio = { version = "0.2.22", features = ["process", "macros"] }
 url = "2.2.0"


### PR DESCRIPTION
Some editors such as `vscode` are exec by a bash script.

`Child.wait()` received a exit code from bash, but vscode is still running.

And the TempDir(`config.fetch.make_view()`) is delete when it goes out of scope.

Then, editor cannot found TempDir.

So, ask `"Proceed with installation?"` in it's scope.