### PR TITLE
Local repo and chroot support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "pacmanconf"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b892ebccc90867a9df918574770c63e785aff95054910efd0fd33e84fd4d462e"
+checksum = "b0731c42e70bc50276db3651c4121c066d48551534637a1fe965594202f29e54"
 dependencies = [
  "cini",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,9 +27,9 @@ dependencies = [
 
 [[package]]
 name = "alpm-utils"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e72295a95926ad5ba4bb6088636d215e8f82c4c3499f1b6f8fb8b4b9e501986"
+checksum = "b1140b0a184059c01fd572de02675e22303d76e1384c62df16260f1e4c1421aa"
 dependencies = [
  "alpm",
 ]
@@ -50,12 +50,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
 
 [[package]]
-name = "arc-swap"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,22 +63,22 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-compression"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9021768bcce77296b64648cc7a7460e3df99979b97ed5c925c38d1cc83778d98"
+checksum = "fb1ff21a63d3262af46b9f33a826a8d134e2d0d9b2179c86034948b732ea8b2a"
 dependencies = [
  "bytes",
  "flate2",
  "futures-core",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -104,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "aur-depends"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c79b37e66e7e43ee65052b154ecb08b5fc8eb8b97541629e76553147209f4f"
+checksum = "85463162e84a8123a77594fc2c9b3862d081d69eeb408a06280574070d62d132"
 dependencies = [
  "alpm",
  "alpm-utils",
@@ -135,9 +129,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bindgen"
@@ -167,9 +161,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -196,9 +190,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
 
 [[package]]
 name = "cexpr"
@@ -242,9 +236,9 @@ checksum = "895f4cd6403d7bd85e13ff3ec635d58183e5e708e7bd70430a91d661b04548e2"
 
 [[package]]
 name = "clang-sys"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa785e9017cb8e8c8045e3f096b7d1ebc4d7337cceccdca8d678a27f788ac133"
+checksum = "0659001ab56b791be01d4b729c44376edc6718cf389a502e579b77b758f3296c"
 dependencies = [
  "glob",
  "libc",
@@ -268,6 +262,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+dependencies = [
+ "cfg-if 0.1.10",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,9 +279,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -285,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "crc32fast"
@@ -300,12 +304,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -390,20 +394,20 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
+checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da80be589a72651dcda34d8b35bcdc9b7254ad06325611074d9cc0fbb19f60ee"
+checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -554,7 +558,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.1",
+ "pin-project 1.0.2",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -677,9 +681,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.13.8"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
+checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -691,7 +695,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 0.4.27",
+ "pin-project 1.0.2",
  "socket2",
  "tokio",
  "tower-service",
@@ -908,7 +912,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -922,7 +926,7 @@ checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
  "mio",
- "miow 0.3.5",
+ "miow 0.3.6",
  "winapi 0.3.9",
 ]
 
@@ -939,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -951,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi 0.3.9",
@@ -961,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
 dependencies = [
  "lazy_static",
  "libc",
@@ -979,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -1042,16 +1046,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "pacmanconf"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7e3230500a7383c852d4604046b2273a2883bf88ea3a3ccbe46f0e0c30570c"
+checksum = "b892ebccc90867a9df918574770c63e785aff95054910efd0fd33e84fd4d462e"
 dependencies = [
  "cini",
 ]
@@ -1216,11 +1210,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
 dependencies = [
- "pin-project-internal 1.0.1",
+ "pin-project-internal 1.0.2",
 ]
 
 [[package]]
@@ -1236,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1250,6 +1244,12 @@ name = "pin-project-lite"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
 
 [[package]]
 name = "pin-utils"
@@ -1265,9 +1265,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "precomputed-hash"
@@ -1368,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "raur"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f334efffb4c97ed33c6be25b66655737a9522781d9ef9aa3c3a7bcd266e66f6c"
+checksum = "194d1a2690ec7b82a8a453360e7b421f2b619edd0c74555d5e2a08a3091a8a02"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -1399,18 +1399,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8963b85b8ce3074fecffde43b4b0dded83ce2f367dc8d363afc56679f3ee820b"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "remove_dir_all"
@@ -1423,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
+checksum = "fb15d6255c792356a0f578d8a645c677904dc02e862bebe2ecc18e0c01b9a0ce"
 dependencies = [
  "async-compression",
  "base64",
@@ -1445,7 +1445,7 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding",
- "pin-project-lite",
+ "pin-project-lite 0.2.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1454,6 +1454,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "web-sys",
  "winreg",
 ]
@@ -1469,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -1502,10 +1503,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework"
-version = "0.4.4"
+name = "scoped-tls"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "security-framework"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1516,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1577,14 +1584,14 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
- "dtoa",
+ "form_urlencoded",
  "itoa",
+ "ryu",
  "serde",
- "url",
 ]
 
 [[package]]
@@ -1605,11 +1612,10 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
+checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
- "arc-swap",
  "libc",
 ]
 
@@ -1627,9 +1633,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "smart-default"
@@ -1644,11 +1650,11 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -1668,9 +1674,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "string_cache"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2940c75beb4e3bf3a494cef919a747a2cb81e52571e212bfbd185074add7208a"
+checksum = "8ddb1139b5353f96e429e1a5e19fbaf663bddedaa06d1dbd49f82e352601209a"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
@@ -1693,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "6c1e438504729046a5cfae47f97c30d6d083c7d91d94603efdae3477fc070d4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1739,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a14cd9f8c72704232f0bfc8455c0e861f0ad4eb60cc9ec8a170e231414c1e13"
+checksum = "4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -1766,15 +1772,24 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
  "bytes",
  "fnv",
@@ -1786,8 +1801,7 @@ dependencies = [
  "mio",
  "mio-named-pipes",
  "mio-uds",
- "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
@@ -1796,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1825,7 +1839,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tokio",
 ]
 
@@ -1837,13 +1851,13 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.0",
  "tracing-core",
 ]
 
@@ -1892,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
@@ -2030,6 +2044,30 @@ name = "wasm-bindgen-shared"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d1cdc8b98a557f24733d50a1199c4b0635e465eecba9c45b214544da197f64"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fb9c67be7439ee8ab1b7db502a49c05e51e2835b66796c705134d9b8e1a585"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,9 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "alpm"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42069961efa8d1854bc666041c87dc25db28705f2bfc68eebc2435ce739fcbdc"
+checksum = "8570c4cdf945380d6b2b9d0aebc6f352db17873586cc0633f9ef4872c8335a10"
 dependencies = [
  "alpm-sys",
  "bitflags",
@@ -18,9 +18,9 @@ dependencies = [
 
 [[package]]
 name = "alpm-sys"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec21bce781ec06de31204090442cfdc33d6b4be496239e82d796cfd8b62b23"
+checksum = "65872b16d1ad141c27edd300915a79f2f6f355deb5ac7fdb7587454cc00d3268"
 dependencies = [
  "bindgen",
 ]
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "aur-depends"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3ca72a874aa969c8b6a70b1fbbc79e041950c6e1b52d3fc1f6f13e513acbfe"
+checksum = "64c79b37e66e7e43ee65052b154ecb08b5fc8eb8b97541629e76553147209f4f"
 dependencies = [
  "alpm",
  "alpm-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,9 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "alpm"
-version = "1.1.4"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8570c4cdf945380d6b2b9d0aebc6f352db17873586cc0633f9ef4872c8335a10"
+checksum = "cca45f53ca76d7e566e05bc08ab09bd4873f5d970ba5c34dc1688c4c1f560b3c"
 dependencies = [
  "alpm-sys",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "aur-depends"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85463162e84a8123a77594fc2c9b3862d081d69eeb408a06280574070d62d132"
+checksum = "47b56e2a3a58f32fe4239847c775ce1d8dd5d3d95300343eb8008d3b45679c25"
 dependencies = [
  "alpm",
  "alpm-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 
 [dependencies]
-alpm = "1.1.4"
+alpm = "1.1.6"
 alpm-utils = "0.6.2"
 aur-depends = "0.11.1"
 aur-fetch = "0.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 [dependencies]
 alpm = "1.1.6"
 alpm-utils = "0.6.2"
-aur-depends = "0.11.1"
+aur-depends = "0.12.0"
 aur-fetch = "0.8.1"
 cini = "0.1.1"
 pacmanconf = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ alpm-utils = "0.6.2"
 aur-depends = "0.11.1"
 aur-fetch = "0.8.1"
 cini = "0.1.1"
-pacmanconf = "0.1.3"
+pacmanconf = "0.2.0"
 raur = "4.0.1"
 srcinfo = "1.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 
 [dependencies]
-alpm = "1.1.3"
-alpm-utils = "0.6.0"
-aur-depends = "0.11.0"
+alpm = "1.1.4"
+alpm-utils = "0.6.2"
+aur-depends = "0.11.1"
 aur-fetch = "0.8.1"
 cini = "0.1.1"
-pacmanconf = "0.1.1"
-raur = "4.0.0"
+pacmanconf = "0.1.3"
+raur = "4.0.1"
 srcinfo = "1.0.0"
 
 
@@ -34,7 +34,7 @@ htmlescape = "0.3.1"
 indicatif = "0.15.0"
 nix = "0.19.0"
 once_cell = "1.5.2"
-reqwest = { version = "0.10.8", features = ["gzip"] }
+reqwest = { version = "0.10.9", features = ["gzip"] }
 rss = { version = "1.9.0", default-features = false }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 [dependencies]
 alpm = "1.1.3"
 alpm-utils = "0.6.0"
-aur-depends = "0.10.0"
+aur-depends = "0.11.0"
 aur-fetch = "0.8.1"
 cini = "0.1.1"
 pacmanconf = "0.1.1"

--- a/paru.conf
+++ b/paru.conf
@@ -21,6 +21,7 @@ DevelSuffixes = -git -cvs -svn -bzr -darcs -always
 #CleanAfter
 #UpgradeMenu
 #NewsOnUpgrade
+#LocalRepo
 
 #
 # Binary OPTIONS

--- a/paru.conf
+++ b/paru.conf
@@ -22,6 +22,7 @@ DevelSuffixes = -git -cvs -svn -bzr -darcs -always
 #UpgradeMenu
 #NewsOnUpgrade
 #LocalRepo
+#Chroot
 
 #
 # Binary OPTIONS

--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -22,7 +22,8 @@ fn pacman_conf(pacman_conf: &str) -> Result<tempfile::NamedTempFile> {
     let conf = conf
         .lines()
         .filter(|l| !l.starts_with("DbPath"))
-        .collect::<String>();
+        .collect::<Vec<_>>()
+        .join("\n");
 
     tmp.as_file_mut().write_all(conf.as_bytes())?;
     tmp.flush()?;

--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -1,0 +1,160 @@
+use crate::config::Config;
+use crate::exec;
+use anyhow::Result;
+use std::ffi::OsStr;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct Chroot {
+    pub path: PathBuf,
+    pub pacman_conf: String,
+    pub makepkg_conf: String,
+    pub ro: Vec<String>,
+    pub rw: Vec<String>,
+}
+
+fn pacman_conf(pacman_conf: &str) -> Result<tempfile::NamedTempFile> {
+    let mut tmp = tempfile::NamedTempFile::new()?;
+    let conf = pacmanconf::Config::expand_from_file(pacman_conf)?;
+
+    // Bug with dbpath in pacstrap
+    let conf = conf
+        .lines()
+        .filter(|l| !l.starts_with("DbPath"))
+        .collect::<String>();
+
+    tmp.as_file_mut().write_all(conf.as_bytes())?;
+    tmp.flush()?;
+    Ok(tmp)
+}
+
+impl Chroot {
+    pub fn exists(&self) -> bool {
+        self.path.join("root").exists()
+    }
+
+    pub fn create<S: AsRef<OsStr>>(&self, config: &Config, pkgs: &[S]) -> Result<()> {
+        let args = &[
+            OsStr::new("install"),
+            OsStr::new("-dm755"),
+            self.path.as_os_str(),
+        ];
+        exec::command(&config.sudo_bin, ".", args)?.success()?;
+
+        let tmp = pacman_conf(&self.pacman_conf)?;
+        let dir = self.path.join("root");
+
+        let mut args = vec![
+            OsStr::new("-C"),
+            tmp.path().as_os_str(),
+            OsStr::new("-M"),
+            OsStr::new(&self.makepkg_conf),
+            dir.as_os_str(),
+        ];
+        args.extend(pkgs.iter().map(|p| p.as_ref()));
+        exec::command("mkarchroot", ".", &args)?.success()?;
+        Ok(())
+    }
+
+    pub fn run<S: AsRef<OsStr>>(&self, args: &[S]) -> Result<()> {
+        let dir = self.path.join("root");
+        let tmp = pacman_conf(&self.pacman_conf)?;
+
+        let mut a = vec![
+            OsStr::new("-C"),
+            tmp.path().as_os_str(),
+            OsStr::new("-M"),
+            OsStr::new(&self.makepkg_conf),
+            dir.as_os_str(),
+        ];
+
+        for file in &self.ro {
+            a.push(OsStr::new("--bind-ro"));
+            a.push(OsStr::new(file));
+        }
+
+        for file in &self.rw {
+            a.push(OsStr::new("--bind"));
+            a.push(OsStr::new(file));
+        }
+
+        a.extend(args.iter().map(|p| p.as_ref()));
+        exec::command("arch-nspawn", ".", &a)?.success()?;
+        Ok(())
+    }
+
+    pub fn update(&self) -> Result<()> {
+        self.run(&["pacman", "-Syu", "--noconfirm"])
+    }
+
+    pub fn build(&self, pkgbuild: &Path, chroot_flags: &[&str], flags: &[&str]) -> Result<()> {
+        let mut args = chroot_flags
+            .iter()
+            .map(|f| OsStr::new(f))
+            .collect::<Vec<_>>();
+        args.push(OsStr::new("-r"));
+        args.push(OsStr::new(self.path.as_os_str()));
+
+        for file in &self.ro {
+            args.push(OsStr::new("-D"));
+            args.push(OsStr::new(file));
+        }
+
+        for file in &self.rw {
+            args.push(OsStr::new("-d"));
+            args.push(OsStr::new(file));
+        }
+
+        args.push(OsStr::new("--"));
+
+        for flag in flags {
+            args.push(OsStr::new(flag));
+        }
+
+        exec::command("makechrootpkg", pkgbuild, &args)?.success()?;
+        Ok(())
+    }
+}
+
+/*pub fn chroot(globals: clap::Globals, ch: clap::Chroot) -> Result<()> {
+    let pacman = pacmanconf::Config::from_file(&globals.pacman_conf)?;
+
+    let chroot = Chroot {
+        path: ch.chroot,
+        pacman_conf: globals.pacman_conf.clone(),
+        makepkg_conf: globals.makepkg_conf.clone(),
+        ro: repo::all_files(&pacman)
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        rw: pacman.cache_dir.clone(),
+    };
+
+    println!("{:?}", chroot);
+
+    if !chroot.path.exists() && !ch.create {
+        bail!("chroot does not exist: use 'chroot -c' to create it");
+    }
+
+    if ch.create {
+        if ch.targets.is_empty() {
+            chroot.create(&["base-devel"])?;
+        } else {
+            chroot.create(&ch.targets)?;
+        }
+    } else if ch.upgrade {
+        chroot.update()?;
+    } else if ch.interactive {
+        let targs: &[&str] = &[];
+        chroot.run(targs)?;
+    } else if ch.sync {
+        let mut cmd = vec!["pacman", "-S", "--ask=255"];
+        cmd.extend(ch.targets.iter().map(|s| s.as_str()));
+        chroot.run(&cmd)?;
+    } else {
+        chroot.run(&ch.targets)?;
+    }
+
+    Ok(())
+}*/

--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -108,7 +108,6 @@ impl Chroot {
         }
 
         args.push(OsStr::new("--"));
-        args.push(OsStr::new("--confirm"));
 
         for flag in flags {
             args.push(OsStr::new(flag));

--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -108,6 +108,7 @@ impl Chroot {
         }
 
         args.push(OsStr::new("--"));
+        args.push(OsStr::new("--confirm"));
 
         for flag in flags {
             args.push(OsStr::new(flag));

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -295,6 +295,7 @@ impl Config {
                 }
             }
             Arg::Long("nochroot") => self.chroot = false,
+            Arg::Long("movepkgs") => self.move_pkgs = true,
             Arg::Long(a) if !arg.is_pacman_arg() => bail!("unknown option --{}", a),
             Arg::Short(a) if !arg.is_pacman_arg() => bail!("unknown option -{}", a),
             _ => (),

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -288,6 +288,13 @@ impl Config {
             //TODO
             Arg::Long("localrepo") => self.repos = LocalRepos::new(value.ok()),
             Arg::Long("local") => self.local = true,
+            Arg::Long("chroot") => {
+                self.chroot = true;
+                if self.repos == LocalRepos::None {
+                    self.repos = LocalRepos::Default;
+                }
+            }
+            Arg::Long("nochroot") => self.chroot = false,
             Arg::Long(a) if !arg.is_pacman_arg() => bail!("unknown option --{}", a),
             Arg::Short(a) if !arg.is_pacman_arg() => bail!("unknown option -{}", a),
             _ => (),

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -227,7 +227,10 @@ impl Config {
             Arg::Long("norebuild") => self.rebuild = "no".into(),
             Arg::Long("topdown") => self.sort_mode = "topdown".to_string(),
             Arg::Long("bottomup") => self.sort_mode = "bottomup".to_string(),
-            Arg::Long("aur") | Arg::Short('a') => self.mode = "aur".to_string(),
+            Arg::Long("aur") | Arg::Short('a') => {
+                self.mode = "aur".to_string();
+                self.aur_filter = true;
+            }
             Arg::Long("repo") => self.mode = "repo".to_string(),
             Arg::Long("gendb") => self.gendb = true,
             Arg::Long("nocheck") => self.no_check = true,

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -1,5 +1,5 @@
 use crate::args::{PACMAN_FLAGS, PACMAN_GLOBALS};
-use crate::config::{Colors, Config};
+use crate::config::{Colors, Config, LocalRepos};
 
 use std::fmt;
 
@@ -282,6 +282,9 @@ impl Config {
                 .extend(value?.split(',').map(|s| s.to_string())),
             Arg::Long("arch") => self.arch = Some(value?.to_string()),
             Arg::Long("color") => self.color = Colors::from(value.unwrap_or("always")),
+            //TODO
+            Arg::Long("localrepo") => self.repos = LocalRepos::new(value.ok()),
+            Arg::Long("local") => self.local = true,
             Arg::Long(a) if !arg.is_pacman_arg() => bail!("unknown option --{}", a),
             Arg::Short(a) if !arg.is_pacman_arg() => bail!("unknown option -{}", a),
             _ => (),
@@ -321,6 +324,7 @@ fn takes_value(arg: Arg) -> TakesValue {
         Arg::Long("redownload") => TakesValue::Optional,
         Arg::Long("rebuild") => TakesValue::Optional,
         Arg::Long("develsuffixes") => TakesValue::Required,
+        Arg::Long("localrepo") => TakesValue::Optional,
         //pacman
         Arg::Long("dbpath") | Arg::Short('b') => TakesValue::Required,
         Arg::Long("root") | Arg::Short('r') => TakesValue::Required,

--- a/src/config.rs
+++ b/src/config.rs
@@ -244,6 +244,7 @@ pub struct Config {
     #[default = "/var/lib/aurbuild/"]
     pub chroot_dir: PathBuf,
     pub chroot: bool,
+    pub move_pkgs: bool,
 
     //pacman
     pub db_path: Option<String>,
@@ -665,6 +666,7 @@ impl Config {
                 }
                 self.chroot = true;
             }
+            "MovePkgs" => self.move_pkgs = true,
             _ => ok1 = false,
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,6 +183,7 @@ pub struct Config {
     pub sort_mode: String,
     #[default = "any"]
     pub mode: String,
+    pub aur_filter: bool,
 
     #[default = 7]
     pub completion_interval: u64,

--- a/src/devel.rs
+++ b/src/devel.rs
@@ -1,6 +1,7 @@
-use crate::config::Config;
+use crate::config::{Config, LocalRepos};
 use crate::download::{self, cache_info_with_warnings, Bases};
 use crate::print_error;
+use crate::repo;
 use crate::util::split_repo_aur_pkgs;
 
 use std::cmp::Ordering;
@@ -170,7 +171,7 @@ pub async fn gendb(config: &mut Config) -> Result<()> {
         bold.paint("Looking for devel repos...")
     );
 
-    let devel_info = fetch_devel_info(config, &bases, srcinfos).await?;
+    let devel_info = fetch_devel_info(config, &bases, &srcinfos).await?;
     save_devel_info(config, &devel_info).context("failed to save devel info")?;
     Ok(())
 }
@@ -257,7 +258,7 @@ pub async fn possible_devel_updates(config: &Config) -> Result<Vec<String>> {
         pkgbases.entry(name).or_default().push(pkg);
     }
 
-    for (pkg, repos) in &devel_info.info {
+    'outer: for (pkg, repos) in &devel_info.info {
         if let Some(pkgs) = pkgbases.get(pkg.as_str()) {
             if pkgs.iter().all(|p| p.should_ignore()) {
                 continue;
@@ -265,6 +266,22 @@ pub async fn possible_devel_updates(config: &Config) -> Result<Vec<String>> {
         }
 
         futures.push(pkg_has_update(config, pkg, &repos.repos));
+        if config.repos != LocalRepos::None {
+            for repo in repo::configured_local_repos(config) {
+                let db = config
+                    .alpm
+                    .syncdbs()
+                    .iter()
+                    .find(|db| db.name() == repo)
+                    .unwrap();
+                if db.pkg(pkg.as_str()).is_ok() {
+                    futures.push(pkg_has_update(config, pkg, &repos.repos));
+                    continue 'outer;
+                }
+            }
+        } else {
+            futures.push(pkg_has_update(config, pkg, &repos.repos));
+        }
     }
 
     let updates = join_all(futures).await;
@@ -344,7 +361,7 @@ async fn has_update(git: &str, flags: &[String], url: &RepoInfo) -> Result<()> {
 pub async fn fetch_devel_info(
     config: &Config,
     bases: &Bases,
-    srcinfos: HashMap<String, Srcinfo>,
+    srcinfos: &HashMap<String, Srcinfo>,
 ) -> Result<DevelInfo> {
     let mut devel_info = DevelInfo::default();
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -9,7 +9,7 @@ use std::process::{Command, Stdio};
 use std::result::Result as StdResult;
 
 use alpm::Version;
-use alpm_utils::{DbListExt, Targ, AsTarg};
+use alpm_utils::{AsTarg, DbListExt, Targ};
 use ansi_term::Style;
 use anyhow::{bail, ensure, Context, Result};
 use aur_depends::Base;
@@ -442,7 +442,10 @@ fn split_repo_aur_pkgbuilds<'a, T: AsTarg>(
         } else if config.mode == "repo" {
             local.push(targ);
         } else if let Some(repo) = targ.repo {
-            if matches!(repo, "testing" | "community-testing" | "core" | "extra" | "community" | "multilib") {
+            if matches!(
+                repo,
+                "testing" | "community-testing" | "core" | "extra" | "community" | "multilib"
+            ) {
                 local.push(targ);
             } else {
                 aur.push(targ);

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -135,6 +135,30 @@ pub fn makepkg<S: AsRef<OsStr>>(config: &Config, dir: &Path, args: &[S]) -> Resu
     Ok(Status(ret.code().unwrap_or(1)))
 }
 
+pub fn command<C: AsRef<OsStr>, S: AsRef<OsStr>, P: AsRef<Path>>(
+    cmd: C,
+    dir: P,
+    args: &[S],
+) -> Result<Status> {
+    let ret = Command::new(cmd.as_ref())
+        .current_dir(dir)
+        .args(args)
+        .spawn()
+        .with_context(|| {
+            format!(
+                "failed to run: {} {}",
+                cmd.as_ref().to_string_lossy(),
+                args.iter()
+                    .map(|a| a.as_ref().to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            )
+        })?
+        .wait()?;
+
+    Ok(Status(ret.code().unwrap_or(1)))
+}
+
 pub fn makepkg_output<S: AsRef<OsStr>>(config: &Config, dir: &Path, args: &[S]) -> Result<Output> {
     let ret = Command::new(&config.makepkg_bin)
         .current_dir(dir)

--- a/src/install.rs
+++ b/src/install.rs
@@ -894,11 +894,11 @@ async fn build_install_pkgbuilds(
                     .unwrap();
                 let path = repo::file(repo).unwrap();
                 let name = repo.name.clone();
-                repo::add(config, path, &name, false, &pkgs)?;
+                repo::add(config, path, &name, config.move_pkgs, &pkgs)?;
                 repo::refresh(config, &[name])?;
             } else {
                 let path = repo::file(&repo).unwrap();
-                repo::add(config, path, &repo.name, false, &pkgs)?;
+                repo::add(config, path, &repo.name, config.move_pkgs, &pkgs)?;
                 repo::refresh(config, &[repo.name.clone()])?;
             }
         }

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,12 +1,13 @@
 use crate::args::Arg;
 use crate::clean::clean_untracked;
 use crate::completion::update_aur_cache;
-use crate::config::Config;
+use crate::config::{Config, LocalRepos};
 use crate::devel::{fetch_devel_info, load_devel_info, save_devel_info, DevelInfo};
 use crate::download::{self, Bases};
 use crate::fmt::{color_repo, print_indent};
 use crate::keys::check_pgp_keys;
 use crate::print_error;
+use crate::repo;
 use crate::upgrade::get_upgrades;
 use crate::util::{ask, get_provider, split_repo_aur_targets, NumberMenu};
 use crate::{args, exec, news};
@@ -22,7 +23,7 @@ use alpm::Alpm;
 use alpm_utils::{DbListExt, Targ};
 use ansi_term::Style;
 use anyhow::{bail, ensure, Context, Result};
-use aur_depends::{Actions, Conflict, Flags, RepoPackage, Resolver};
+use aur_depends::{Actions, AurPackage, Base, Conflict, Flags, RepoPackage, Resolver};
 use raur::Cache;
 use srcinfo::Srcinfo;
 
@@ -43,6 +44,11 @@ fn early_pacman(config: &Config, targets: Vec<String>) -> Result<()> {
 }
 
 pub async fn install(config: &mut Config, targets_str: &[String]) -> Result<i32> {
+    if config.local && config.args.has_arg("y", "refresh") {
+        repo::refresh(config, targets_str)?;
+        return Ok(0);
+    }
+
     let mut cache = Cache::new();
     let c = config.color;
 
@@ -70,6 +76,7 @@ pub async fn install(config: &mut Config, targets_str: &[String]) -> Result<i32>
 
     let targets = args::parse_targets(&targets_str);
     let (mut repo_targets, aur_targets) = split_repo_aur_targets(config, &targets);
+    let mut done_something = false;
 
     if targets_str.is_empty()
         && !config.args.has_arg("u", "sysupgrade")
@@ -89,6 +96,7 @@ pub async fn install(config: &mut Config, targets_str: &[String]) -> Result<i32>
         {
             let targets = repo_targets.iter().map(|t| t.to_string()).collect();
             repo_targets.clear();
+            done_something = true;
             early_pacman(config, targets)?;
         }
     }
@@ -137,7 +145,9 @@ pub async fn install(config: &mut Config, targets_str: &[String]) -> Result<i32>
 
     if targets.is_empty() {
         print_warnings(config, &cache, None);
-        println!(" there is nothing to do");
+        if !done_something {
+            println!(" there is nothing to do");
+        }
         return Ok(0);
     }
 
@@ -178,24 +188,55 @@ pub async fn install(config: &mut Config, targets_str: &[String]) -> Result<i32>
             false
         };
 
-    let err = install_actions(config, &mut actions, &conflicts.0, &conflicts.1).await;
+    if !ask(config, "Proceed to review?", true) {
+        return Ok(1);
+    }
+
+    let bases = Bases::from_iter(actions.iter_build_pkgs().map(|p| p.pkg.clone()));
+    let srcinfos = download_pkgbuilds(config, &bases).await?;
+
+    let mut err = install_actions(config, &mut actions, &srcinfos, &bases).await;
+
+    let conflicts = conflicts
+        .0
+        .iter()
+        .map(|c| c.pkg.as_str())
+        .chain(conflicts.1.iter().map(|c| c.pkg.as_str()))
+        .collect::<HashSet<_>>();
+
+    let mut build = actions.build;
+    let install_targets = actions
+        .install
+        .iter()
+        .filter(|p| p.make)
+        .map(|p| p.pkg.name().to_string())
+        .collect::<Vec<_>>();
+
+    if err.is_ok() {
+        //download_pkgbuild_sources(config, &actions.build)?;
+        err = build_install_pkgbuilds(
+            config,
+            &mut build,
+            &srcinfos,
+            &upgrades.aur_repos,
+            &bases,
+            &conflicts,
+        )
+        .await;
+    }
 
     if remove_make {
         let mut args = config.pacman_globals();
         args.op("remove").arg("noconfirm");
-        args.targets = actions
-            .iter_build_pkgs()
+        args.targets = build
+            .iter()
+            .flat_map(|b| &b.pkgs)
             .filter(|p| p.make)
             .map(|p| p.pkg.name.as_str())
             .collect();
 
-        args.targets.extend(
-            actions
-                .install
-                .iter()
-                .filter(|p| p.make)
-                .map(|p| p.pkg.name()),
-        );
+        args.targets
+            .extend(install_targets.iter().map(|s| s.as_str()));
 
         if let Err(err) = exec::pacman(config, &args) {
             print_error(config.color.error, err);
@@ -203,7 +244,7 @@ pub async fn install(config: &mut Config, targets_str: &[String]) -> Result<i32>
     }
 
     if config.clean_after {
-        for base in &actions.build {
+        for base in &build {
             let path = config.build_dir.join(base.package_base());
             if let Err(err) = clean_untracked(config, &path) {
                 print_error(config.color.error, err);
@@ -214,17 +255,10 @@ pub async fn install(config: &mut Config, targets_str: &[String]) -> Result<i32>
     err
 }
 
-async fn install_actions<'a>(
+async fn download_pkgbuilds<'a>(
     config: &Config,
-    actions: &mut Actions<'a>,
-    conflicts: &[Conflict],
-    inner_conflicts: &[Conflict],
-) -> Result<i32> {
-    if !ask(config, "Proceed to review?", true) {
-        return Ok(1);
-    }
-
-    let bases = Bases::from_iter(actions.iter_build_pkgs().map(|p| p.pkg.clone()));
+    bases: &Bases,
+) -> Result<HashMap<String, Srcinfo>> {
     let mut srcinfos = HashMap::new();
 
     for base in &bases.bases {
@@ -254,7 +288,15 @@ async fn install_actions<'a>(
             bail!("could not find .SRINFO for '{}'", base.package_base());
         }
     }
+    Ok(srcinfos)
+}
 
+async fn install_actions<'a>(
+    config: &Config,
+    actions: &mut Actions<'a>,
+    srcinfos: &HashMap<String, Srcinfo>,
+    bases: &Bases,
+) -> Result<i32> {
     let pkgs = actions
         .build
         .iter()
@@ -355,15 +397,6 @@ async fn install_actions<'a>(
     tokio::spawn(async move {
         let _ = update_aur_cache(&url, &dir, Some(interval)).await;
     });
-
-    let conflicts = conflicts
-        .iter()
-        .map(|c| c.pkg.as_str())
-        .chain(inner_conflicts.iter().map(|c| c.pkg.as_str()))
-        .collect::<HashSet<_>>();
-
-    //download_pkgbuild_sources(config, &actions.build)?;
-    build_install_pkgbuilds(config, &mut actions.build, srcinfos, &bases, &conflicts).await?;
 
     Ok(0)
 }
@@ -669,12 +702,13 @@ fn do_install(
 }
 
 async fn build_install_pkgbuilds(
-    config: &Config,
+    config: &mut Config,
     build: &mut [aur_depends::Base],
-    srcinfos: HashMap<String, Srcinfo>,
+    srcinfos: &HashMap<String, Srcinfo>,
+    aur_repos: &HashMap<String, String>,
     bases: &Bases,
     conflicts: &HashSet<&str>,
-) -> Result<()> {
+) -> Result<i32> {
     let mut deps = Vec::new();
     let mut exp = Vec::new();
     let mut install_queue = Vec::new();
@@ -690,6 +724,23 @@ async fn build_install_pkgbuilds(
     } else {
         (DevelInfo::default(), DevelInfo::default())
     };
+
+    let repo = repo::configured_local_repos(config);
+    let repo = repo.get(0).map(|repo| {
+        config
+            .pacman
+            .repos
+            .iter()
+            .find(|r| r.name == *repo)
+            .unwrap()
+    });
+
+    if let Some(repo) = repo {
+        let file = repo::file(repo).unwrap();
+        repo::init(config, file, &repo.name)?;
+    }
+
+    let repo = repo.cloned();
 
     for base in build {
         let mut debug_paths = Vec::new();
@@ -767,40 +818,7 @@ async fn build_install_pkgbuilds(
             base.pkgs.extend(debug);
         }
 
-        if config.args.has_arg("needed", "needed") {
-            let mut all_installed = true;
-
-            for pkg in &base.pkgs {
-                if let Ok(pkg) = config.alpm.localdb().pkg(&*pkg.pkg.name) {
-                    if pkg.version().as_str() == version {
-                        continue;
-                    }
-                }
-
-                all_installed = false;
-                break;
-            }
-
-            if all_installed {
-                println!(
-                    "{} {}-{} is up to date -- skipping",
-                    c.warning.paint("::"),
-                    base.package_base(),
-                    base.pkgs[0].pkg.version
-                );
-                continue;
-            }
-        }
-
-        let needs_build = base
-            .pkgs
-            .iter()
-            .any(|p| !Path::new(pkgdest.get(&p.pkg.name).unwrap()).exists());
-
-        if needs_build
-            || (config.rebuild == "yes" && base.pkgs.iter().any(|p| p.target))
-            || config.rebuild == "all"
-        {
+        if needs_build(config, base, &pkgdest, &version) {
             // actual build
             exec::makepkg(
                 config,
@@ -826,19 +844,29 @@ async fn build_install_pkgbuilds(
             }
         }
 
+        if let Some(ref repo) = repo {
+            let pkgs = pkgdest.values().collect::<Vec<_>>();
+            if let Some(repo) = aur_repos.get(base.package_base()) {
+                let repo = config
+                    .pacman
+                    .repos
+                    .iter()
+                    .find(|db| db.name == *repo)
+                    .unwrap();
+                let path = repo::file(repo).unwrap();
+                let name = repo.name.clone();
+                repo::add(config, path, &name, false, &pkgs)?;
+                repo::refresh(config, &[name])?;
+            } else {
+                let path = repo::file(&repo).unwrap();
+                repo::add(config, path, &repo.name, false, &pkgs)?;
+                repo::refresh(config, &[repo.name.clone()])?;
+            }
+        }
+
         for pkg in &base.pkgs {
-            if config.args.has_arg("needed", "needed") {
-                if let Ok(pkg) = config.alpm.localdb().pkg(&*pkg.pkg.name) {
-                    if pkg.version().as_str() == version {
-                        println!(
-                            "{} {}-{} is up to date -- skipping install",
-                            c.warning.paint("::"),
-                            base.package_base(),
-                            base.pkgs[0].pkg.version
-                        );
-                        continue;
-                    }
-                }
+            if !needs_install(config, base, &version, pkg) {
+                continue;
             }
 
             if config.globals.has_arg("asexplicit", "asexplicit") {
@@ -883,7 +911,7 @@ async fn build_install_pkgbuilds(
         &mut devel_info,
     )?;
 
-    Ok(())
+    Ok(0)
 }
 
 fn asdeps(config: &Config, pkgs: &[&str]) -> Result<()> {
@@ -980,6 +1008,12 @@ fn flags(config: &mut Config) -> aur_depends::Flags {
     }
     if config.op == "yay" {
         flags.remove(Flags::TARGET_PROVIDES);
+    }
+    if config.repos != LocalRepos::None {
+        flags |= Flags::LOCAL_REPO;
+    }
+    if !config.aur_namespace() {
+        flags.remove(Flags::AUR_NAMESPACE);
     }
 
     flags
@@ -1149,4 +1183,83 @@ fn print_warnings(config: &Config, cache: &Cache, actions: Option<&Actions>) {
     warnings.orphans.dedup();
 
     warnings.all(config.color, config.cols);
+}
+
+fn needs_build(
+    config: &Config,
+    base: &Base,
+    pkgdest: &HashMap<String, String>,
+    version: &str,
+) -> bool {
+    if (config.rebuild == "yes" && base.pkgs.iter().any(|p| p.target)) || config.rebuild == "all" {
+        return true;
+    }
+
+    if config.args.has_arg("needed", "needed") {
+        let mut all_installed = true;
+        let c = config.color;
+
+        if config.repos != LocalRepos::None {
+            let dbs = config.alpm.syncdbs();
+            let repos = repo::configured_local_repos(config);
+
+            for pkg in &base.pkgs {
+                for repo in &repos {
+                    let repo = dbs.iter().find(|db| db.name() == *repo).unwrap();
+                    if let Ok(pkg) = repo.pkg(pkg.pkg.name.as_str()) {
+                        if pkg.version() != version {
+                            return true;
+                        }
+                    } else {
+                        return true;
+                    }
+                }
+            }
+        } else {
+            for pkg in &base.pkgs {
+                if let Ok(pkg) = config.alpm.localdb().pkg(&*pkg.pkg.name) {
+                    if pkg.version() == version {
+                        continue;
+                    }
+                }
+
+                all_installed = false;
+                break;
+            }
+
+            if all_installed {
+                println!(
+                    "{} {}-{} is up to date -- skipping",
+                    c.warning.paint("::"),
+                    base.package_base(),
+                    base.pkgs[0].pkg.version
+                );
+                return false;
+            }
+        }
+    }
+
+    !base
+        .pkgs
+        .iter()
+        .all(|p| Path::new(pkgdest.get(&p.pkg.name).unwrap()).exists())
+}
+
+fn needs_install(config: &Config, base: &Base, version: &str, pkg: &AurPackage) -> bool {
+    if config.args.has_arg("needed", "needed") {
+        if let Ok(pkg) = config.alpm.localdb().pkg(&*pkg.pkg.name) {
+            if pkg.version().as_str() == version {
+                let c = config.color;
+                println!(
+                    "{} {}-{} is up to date -- skipping install",
+                    c.warning.paint("::"),
+                    base.package_base(),
+                    base.pkgs[0].pkg.version
+                );
+                return false;
+            }
+        }
+    }
+
+    true
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -810,7 +810,9 @@ async fn build_install_pkgbuilds(
         }
 
         if config.chroot {
-            chroot.build(&dir, &["-cu"], &["-ofA"])?;
+            chroot
+                .build(&dir, &["-cu"], &["-ofA"])
+                .with_context(|| format!("failed to download sources for '{}'", base))?;
         } else {
             // download sources
             exec::makepkg(config, &dir, &["--verifysource", "-ACcf"])?
@@ -852,11 +854,13 @@ async fn build_install_pkgbuilds(
         if needs_build(config, base, &pkgdest, &version) {
             // actual build
             if config.chroot {
-                chroot.build(
-                    &dir,
-                    &[],
-                    &["-feA", "--noconfirm", "--noprepare", "--holdver"],
-                )?;
+                chroot
+                    .build(
+                        &dir,
+                        &[],
+                        &["-feA", "--noconfirm", "--noprepare", "--holdver"],
+                    )
+                    .with_context(|| format!("failed to build '{}'", base))?;
             } else {
                 exec::makepkg(
                     config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ mod install;
 mod keys;
 mod news;
 mod query;
+mod remove;
+mod repo;
 mod search;
 mod sync;
 mod upgrade;
@@ -23,7 +25,6 @@ mod util;
 extern crate smart_default;
 
 use crate::config::Config;
-use crate::devel::{load_devel_info, save_devel_info};
 use crate::query::print_upgrade_list;
 
 use std::error::Error as StdError;
@@ -175,21 +176,7 @@ async fn handle_yay(config: &mut Config) -> Result<i32> {
 }
 
 fn handle_remove(config: &mut Config) -> Result<i32> {
-    let mut devel_info = load_devel_info(config)?.unwrap_or_default();
-
-    let ret = exec::pacman(config, &config.args)?.code();
-
-    if ret == 0 {
-        for target in &config.targets {
-            devel_info.info.remove(target);
-        }
-
-        if let Err(err) = save_devel_info(config, &devel_info) {
-            print_error(config.color.error, err);
-        }
-    }
-
-    Ok(0)
+    remove::remove(config)
 }
 
 async fn handle_sync(config: &mut Config) -> Result<i32> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,10 +109,11 @@ async fn run(config: &mut Config) -> Result<i32> {
 
 async fn handle_cmd(config: &mut Config) -> Result<i32> {
     let ret = match config.op.as_str() {
-        "database" | "files" | "deptest" | "upgrade" => exec::pacman(config, &config.args)?.code(),
+        "database" | "files" | "upgrade" => exec::pacman(config, &config.args)?.code(),
         "query" => handle_query(config).await?,
         "sync" => handle_sync(config).await?,
         "remove" => handle_remove(config)?,
+        "deptest" => handle_test(config).await?,
         "getpkgbuild" => handle_get_pkg_build(config).await?,
         "show" => handle_show(config).await?,
         "yay" => handle_yay(config).await?,
@@ -177,6 +178,14 @@ async fn handle_yay(config: &mut Config) -> Result<i32> {
 
 fn handle_remove(config: &mut Config) -> Result<i32> {
     remove::remove(config)
+}
+
+async fn handle_test(config: &Config) -> Result<i32> {
+    if config.aur_filter {
+        sync::filter(config).await
+    } else {
+        Ok(exec::pacman(config, &config.args)?.code())
+    }
 }
 
 async fn handle_sync(config: &mut Config) -> Result<i32> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(feature = "backtrace", feature(backtrace))]
 
 mod args;
+mod chroot;
 mod clean;
 mod command_line;
 mod completion;

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -1,0 +1,67 @@
+use crate::devel::{load_devel_info, save_devel_info};
+use crate::print_error;
+use crate::Config;
+use crate::{exec, repo};
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+pub fn remove(config: &mut Config) -> Result<i32> {
+    let mut devel_info = load_devel_info(config)?.unwrap_or_default();
+    let db = config.alpm.localdb();
+    let bases = config
+        .targets
+        .iter()
+        .filter_map(|pkg| db.pkg(pkg.as_str()).ok())
+        .map(|pkg| pkg.base().unwrap_or(pkg.name()))
+        .collect::<Vec<_>>();
+
+    let mut db_map: HashMap<String, Vec<String>> = HashMap::new();
+    let dbs = config.alpm.syncdbs();
+    let local_repos = repo::configured_local_repos(config);
+    let local_dbs = local_repos
+        .iter()
+        .filter_map(|r| dbs.iter().find(|db| db.name() == *r))
+        .collect::<Vec<_>>();
+
+    for pkg in &config.targets {
+        for db in &local_dbs {
+            if let Ok(pkg) = db.pkg(pkg.as_str()) {
+                db_map
+                    .entry(db.name().to_string())
+                    .or_default()
+                    .push(pkg.name().to_string());
+            }
+        }
+    }
+
+    let mut ret = exec::pacman(config, &config.args)?.code();
+    if ret != 0 {
+        return Ok(ret);
+    }
+
+    for target in bases {
+        devel_info.info.remove(target);
+    }
+
+    if let Err(err) = save_devel_info(config, &devel_info) {
+        print_error(config.color.error, err);
+        ret = 1;
+    }
+
+    if config.local {
+        for (db, pkgs) in &db_map {
+            let db = local_dbs.iter().find(|d| d.name() == *db).unwrap();
+            let name = db.name();
+            let path = db.servers().first().unwrap().trim_start_matches("file://");
+            let _ = repo::remove(config, path, name, &pkgs);
+        }
+        repo::refresh(
+            config,
+            &db_map.keys().map(|s| s.as_str()).collect::<Vec<_>>(),
+        )?;
+    }
+
+    Ok(ret)
+}

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,0 +1,221 @@
+use crate::config::{Config, LocalRepos};
+use crate::exec;
+
+use std::env::current_exe;
+use std::ffi::OsStr;
+use std::fs::read_link;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+pub fn add<P: AsRef<Path>, S: AsRef<OsStr>>(
+    config: &Config,
+    path: P,
+    name: &str,
+    mv: bool,
+    pkgs: &[S],
+) -> Result<()> {
+    let db = path.as_ref().join(format!("{}.db", name));
+    let name = if db.exists() {
+        if pkgs.is_empty() {
+            return Ok(());
+        }
+        read_link(db)?
+    } else if !name.contains(".db.") {
+        PathBuf::from(format!("{}.db.tar.gz", name))
+    } else {
+        PathBuf::from(name)
+    };
+
+    let path = path.as_ref();
+    let file = path.join(&name);
+    let sudo = OsStr::new(&config.sudo_bin);
+
+    exec::command(
+        sudo,
+        ".",
+        &[OsStr::new("mkdir"), OsStr::new("-p"), path.as_os_str()],
+    )?
+    .success()?;
+
+    let mut args = vec![OsStr::new("repo-add"), OsStr::new("-R"), file.as_os_str()];
+    args.extend(pkgs.iter().map(|p| p.as_ref()));
+    exec::command(sudo, ".", &args)?.success()?;
+
+    if !pkgs.is_empty() {
+        let cmd = if mv {
+            OsStr::new("mv")
+        } else {
+            OsStr::new("cp")
+        };
+
+        let mut args = vec![cmd];
+        args.extend(pkgs.iter().map(OsStr::new));
+        args.push(path.as_os_str());
+        exec::command(sudo, ".", &args)?.success()?;
+    }
+
+    Ok(())
+}
+
+pub fn remove<P: AsRef<Path>, S: AsRef<OsStr>>(
+    config: &Config,
+    path: P,
+    name: &str,
+    pkgs: &[S],
+) -> Result<()> {
+    let path = path.as_ref();
+    let db = path.join(format!("{}.db", name));
+    if pkgs.is_empty() || !db.exists() {
+        return Ok(());
+    }
+
+    let name = read_link(db)?;
+    let file = path.join(&name);
+
+    let mut args = vec![OsStr::new("repo-remove"), file.as_os_str()];
+    args.extend(pkgs.iter().map(|p| p.as_ref()));
+    exec::command(&config.sudo_bin, ".", &args)?.success()?;
+
+    Ok(())
+}
+
+pub fn init<P: AsRef<Path>>(config: &Config, path: P, name: &str) -> Result<()> {
+    let pkgs: &[&str] = &[];
+    add(config, path, name, false, pkgs)
+}
+
+pub fn configured_local_repos(config: &Config) -> Vec<&str> {
+    config
+        .pacman
+        .repos
+        .iter()
+        .filter(|r| is_configured_local_repo(config, r))
+        .map(|r| r.name.as_str())
+        .collect()
+}
+
+pub fn is_configured_local_repo(config: &Config, repo: &pacmanconf::Repository) -> bool {
+    match config.repos {
+        LocalRepos::None => false,
+        LocalRepos::Default => is_local(repo),
+        LocalRepos::Repo(ref r) => r.iter().any(|r| *r == repo.name),
+    }
+}
+
+pub fn file(repo: &pacmanconf::Repository) -> Option<&str> {
+    repo.servers
+        .first()
+        .map(|s| s.trim_start_matches("file://"))
+}
+
+pub fn is_local(repo: &pacmanconf::Repository) -> bool {
+    !repo.servers.is_empty() && repo.servers.iter().all(|s| s.starts_with("file://"))
+}
+
+pub fn is_local_db(db: &alpm::Db) -> bool {
+    !db.servers().is_empty() && db.servers().iter().all(|s| s.starts_with("file://"))
+}
+
+pub fn refresh<S: AsRef<OsStr>>(config: &mut Config, repos: &[S]) -> Result<i32> {
+    let exe = current_exe().context("failed to get current exe")?;
+    let c = config.color;
+    if !nix::unistd::getuid().is_root() {
+        let mut cmd = Command::new(&config.sudo_bin);
+
+        cmd.arg(exe);
+
+        if let Some(ref conf) = config.pacman_conf {
+            cmd.arg("--config").arg(conf);
+        }
+
+        cmd.arg("--dbpath")
+            .arg(config.alpm.dbpath())
+            .arg("-Sy")
+            .arg("--local")
+            .args(repos);
+
+        let status = cmd.spawn()?.wait()?;
+
+        return Ok(status.code().unwrap_or(1));
+    }
+
+    let mut dbs = config.alpm.syncdbs_mut().to_list();
+    dbs.retain(|db| is_local_db(db));
+
+    if !repos.is_empty() {
+        dbs.retain(|db| repos.iter().any(|r| r.as_ref() == db.name()));
+    }
+
+    println!(
+        "{} {}",
+        c.action.paint("::"),
+        c.bold.paint("syncing local databases...")
+    );
+
+    if !dbs.is_empty() {
+        #[cfg(feature = "git")]
+        dbs.update(false)?;
+        #[cfg(not(feature = "git"))]
+        for mut db in &dbs {
+            println!("  syncing {}.db...", db.name());
+            db.update(false)?;
+        }
+    } else {
+        println!("  nothing to do");
+    }
+
+    Ok(0)
+}
+
+/*pub fn repo(globals: Globals, repo: Repo) -> Result<()> {
+    sudo_reexec();
+
+    let pacman = pacmanconf::Config::from_file(&globals.pacman_conf)?;
+
+    if repo.create {
+        for r in &repo.repos {
+            let path = Path::new(&repo.path).join(r);
+            init(&path, r, repo.quiet)?;
+            println!("created repository {}", path.display());
+
+            if repo.append {
+                if pacman.repos.iter().any(|repo| repo.name == *r) {
+                    eprintln!("error: repo {} already exists in pacman.conf", r);
+                    continue;
+                }
+                println!("appending repo to pacman.conf");
+                append(&globals, &path, r)?;
+            }
+        }
+    } else if repo.add {
+        let main_repo = match repo.repo {
+            Some(ref r) => r.as_str(),
+            None => {
+                let repos = local_repos(&pacman);
+                repos
+                    .first()
+                    .context("no local repos configured")?
+                    .name
+                    .as_str()
+            }
+        };
+
+        let path = Path::new(&repo.path).join(&main_repo);
+        add(&path, &main_repo, repo.quiet, repo.mv, &repo.repos)?;
+
+        if repo.refresh {
+            let mut cmd = globals.sudo_command();
+            cmd.arg("refresh").arg(main_repo);
+            run(cmd)?;
+        }
+    } else {
+        for repo in local_repos(&pacman) {
+            let file = file(&repo).unwrap();
+            println!("[{}] {}", repo.name, file);
+        }
+    }
+    Ok(())
+}
+*/

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -110,6 +110,23 @@ pub fn file(repo: &pacmanconf::Repository) -> Option<&str> {
         .map(|s| s.trim_start_matches("file://"))
 }
 
+pub fn all_files(config: &Config) -> Vec<&str> {
+    config
+        .pacman
+        .repos
+        .iter()
+        .filter(|r| is_configured_local_repo(config, r))
+        .flat_map(|r| files(r))
+        .collect()
+}
+
+pub fn files(repo: &pacmanconf::Repository) -> Vec<&str> {
+    repo.servers
+        .iter()
+        .map(|s| s.trim_start_matches("file://"))
+        .collect()
+}
+
 pub fn is_local(repo: &pacmanconf::Repository) -> bool {
     !repo.servers.is_empty() && repo.servers.iter().all(|s| s.starts_with("file://"))
 }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -39,10 +39,6 @@ pub fn add<P: AsRef<Path>, S: AsRef<OsStr>>(
     )?
     .success()?;
 
-    let mut args = vec![OsStr::new("repo-add"), OsStr::new("-R"), file.as_os_str()];
-    args.extend(pkgs.iter().map(|p| p.as_ref()));
-    exec::command(sudo, ".", &args)?.success()?;
-
     if !pkgs.is_empty() {
         let cmd = if mv {
             OsStr::new("mv")
@@ -50,11 +46,20 @@ pub fn add<P: AsRef<Path>, S: AsRef<OsStr>>(
             OsStr::new("cp")
         };
 
-        let mut args = vec![cmd];
+        let mut args = vec![cmd, OsStr::new("-f")];
         args.extend(pkgs.iter().map(OsStr::new));
         args.push(path.as_os_str());
         exec::command(sudo, ".", &args)?.success()?;
     }
+
+    let mut args = vec![OsStr::new("repo-add"), OsStr::new("-R"), file.as_os_str()];
+    let pkgs = pkgs
+        .iter()
+        .map(|p| path.join(Path::new(p.as_ref()).file_name().unwrap()))
+        .collect::<Vec<_>>();
+
+    args.extend(pkgs.iter().map(|p| p.as_os_str()));
+    exec::command(sudo, ".", &args)?.success()?;
 
     Ok(())
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -303,7 +303,7 @@ pub async fn search_install(config: &mut Config) -> Result<i32> {
                     AnyPkg::RepoPkg(pkg) => {
                         pkgs.push(format!("{}/{}", pkg.db().unwrap().name(), pkg.name()))
                     }
-                    AnyPkg::AurPkg(pkg) => pkgs.push(format!("aur/{}", pkg.name)),
+                    AnyPkg::AurPkg(pkg) => pkgs.push(format!("__aur__/{}", pkg.name)),
                 }
             }
         }
@@ -314,7 +314,7 @@ pub async fn search_install(config: &mut Config) -> Result<i32> {
                     AnyPkg::RepoPkg(pkg) => {
                         pkgs.push(format!("{}/{}", pkg.db().unwrap().name(), pkg.name()))
                     }
-                    AnyPkg::AurPkg(pkg) => pkgs.push(format!("aur/{}", pkg.name)),
+                    AnyPkg::AurPkg(pkg) => pkgs.push(format!("__aur__/{}", pkg.name)),
                 }
             }
         }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,8 +1,21 @@
 use crate::config::Config;
 use crate::{exec, repo};
 
-use anyhow::{ensure, Context, Result};
 use std::io::Write;
+
+use anyhow::{ensure, Context, Result};
+use raur::Raur;
+
+pub async fn filter(config: &Config) -> Result<i32> {
+    let mut cache = raur::Cache::new();
+    config.raur.cache_info(&mut cache, &config.targets).await?;
+
+    for targ in config.targets.iter().filter(|t| cache.contains(t.as_str())) {
+        println!("{}", targ);
+    }
+
+    Ok(0)
+}
 
 pub async fn list(config: &Config) -> Result<i32> {
     let mut args = config.pacman_args();

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,26 +1,35 @@
 use crate::config::Config;
-use crate::exec;
+use crate::{exec, repo};
 
 use anyhow::{ensure, Context, Result};
 use std::io::Write;
 
 pub async fn list(config: &Config) -> Result<i32> {
     let mut args = config.pacman_args();
+
+    if config.local {
+        args.targets = repo::configured_local_repos(&config);
+    }
+
+    let mut show_aur = args.targets.is_empty() && config.mode != "repo";
     let dbs = config.alpm.syncdbs();
 
     if args.targets.is_empty() {
-        args.targets = dbs.iter().map(|db| db.name()).collect();
-        args.target("aur")
+        if config.mode != "aur" {
+            args.targets = dbs.iter().map(|db| db.name()).collect();
+        }
     };
 
-    let has_aur = args.targets.contains(&"aur");
-    args.targets.retain(|&t| t != "aur");
+    if config.aur_namespace() {
+        show_aur |= args.targets.contains(&"aur");
+        args.targets.retain(|&t| t != "aur");
+    }
 
     if !args.targets.is_empty() {
         exec::pacman(config, &args)?;
     }
 
-    if has_aur {
+    if show_aur {
         list_aur(config).await?;
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -55,7 +55,7 @@ pub fn split_repo_aur_targets<'a, T: AsTarg>(
         } else if config.mode == "repo" {
             local.push(targ);
         } else if let Some(repo) = targ.repo {
-            if repo == "aur" {
+            if config.aur_namespace() && repo == "aur" {
                 aur.push(targ);
             } else {
                 local.push(targ);

--- a/src/util.rs
+++ b/src/util.rs
@@ -57,6 +57,9 @@ pub fn split_repo_aur_targets<'a, T: AsTarg>(
         } else if let Some(repo) = targ.repo {
             if config.aur_namespace() && repo == "aur" {
                 aur.push(targ);
+            } else if repo == "__aur__" {
+                // hack for search install
+                aur.push(targ);
             } else {
                 local.push(targ);
             }


### PR DESCRIPTION
This PR adds support for both local repos and building in a clean chroot.

# Local Repo

Local repo support can be enabled via the `LocalRepo` option in paru.conf or via the `--localrepo` flag. When this option is enabled, all local repos will enabled by paru. The first one will be where paru builds new packages. However if a package already exists in another local repo, then paru will build it there.

The local repo option also supports taking a list of repos to use. For example `LocalRepo = aur git foo` will cause paru to recognise these local repos. Only building/checking for updates in these repos. Again, the first repo will be where paru builds new packages.

If there are no local repos configured, paru will suggest you add one to your pacman.conf. It will not do this for you. However paru will create repos for you if they are listed in pacman.conf. Meaning all you need to do is add a repo to pacman.conf and not fiddle with pacman.conf.

There's a feature I like to call `aur namespace`. This is simply the existence of a virtual `aur` repo that can be used during `-S`. For example `paru -S aur/foo` will attempt to find foo in the AUR and not from some repo named AUR. This feature is now disabled if there happens to be a repo named aur in your pacman.conf.

One thing you may not expect is that paru still prioritises repos over the aur. This means the first time you install something to a local repo, paru will grab it from the AUR, the second time it will see it in the repo and not try the AUR at all. If you wish to avoid this do `paru -Sa <pkg>` or just set `AurOnly` in the aur. This does not apply to `-Su` though, paru will know to lookup the local repo packages in the AUR.

Similar `-G` will require a `-a` if the package exists in a local repo.

 # Chroot

Chroot builds can be enabled with the `Chroot` option in paru.conf, of via the `--chroot` flag. This option implies LocalRepo. When chroot is enabled, packages will be built in a clean chroot. Paru will create the chroot for you.

With chroot builds `paru -Sw` is now possible.

# Other Options

`paru -Sy --local` can be used to refresh local repos.
`paru -R --local` can be used to remove a package from a local repo as well as the system.
`paru -Ta` can be used to filter a list of packages to aur packages.
`paru -Sl --local` can be used to list packages belonging to local repos.

Usually people list installed AUR packages with `pacman -Qqm`. However this may include foreign packages that are not actually in the AUR.

Now it is possible to do `pacman -Qmq | paru -Ta -`. And for local repo users you can do `paru -Slq --local | paru -Ta`.

# TODO

I plan to also add `paru -C` and `paru -L` to manage chroots and local repos respectively. For now `paru -Sy --local` and `paru -R --local` some what fill the missing options. They may be removed when -C/-L are added.

# Bugs

Somewhat randomly packages appear to be corrupt. I have no idea why this happens. Especially as the message says the package is in `/var/cache/pacman/pkg`, but there's no reason for a package to be there. The local repo itself is a cachedir, so why would pacman copy packages into there? /shrug 