### PR TITLE
Add example for "Packages for exclude" user input

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -286,7 +286,7 @@ pub async fn search_install(config: &mut Config) -> Result<i32> {
         }
     }
 
-    let input = input(config, "Packages to install (eg: 1 2 3, 1-3 or ^4): ");
+    let input = input(config, "Packages to install (eg: 1 2 3, 1-3 or ^4):");
 
     if input.trim().is_empty() {
         println!(" there is nothing to do");

--- a/src/search.rs
+++ b/src/search.rs
@@ -286,7 +286,7 @@ pub async fn search_install(config: &mut Config) -> Result<i32> {
         }
     }
 
-    let input = input(config, "Packages to install (eg: 1 2 3, 1-3 or ^4):");
+    let input = input(config, "Packages to install (eg: 1 2 3, 1-3):");
 
     if input.trim().is_empty() {
         println!(" there is nothing to do");

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -273,7 +273,7 @@ pub async fn get_upgrades<'a, 'b>(
         );
     }
 
-    let input = input(config, "Packages to exclude:");
+    let input = input(config, "Packages to exclude (eg: 1 2 3, 1-3):");
     let input = input.trim();
     let number_menu = NumberMenu::new(&input);
 

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -273,7 +273,7 @@ pub async fn get_upgrades<'a, 'b>(
         );
     }
 
-    let input = input(config, "Packages to exclude: ");
+    let input = input(config, "Packages to exclude:");
     let input = input.trim();
     let number_menu = NumberMenu::new(&input);
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -114,7 +114,8 @@ pub fn ask(config: &Config, question: &str, default: bool) -> bool {
 pub fn input(config: &Config, question: &str) -> String {
     let action = config.color.action;
     let bold = config.color.bold;
-    print!("{} {}", action.paint("::"), bold.paint(question),);
+    println!("{} {}", action.paint("::"), bold.paint(question));
+    print!("{} ", action.paint("::"));
     let _ = stdout().lock().flush();
     if config.no_confirm {
         println!();


### PR DESCRIPTION
* Added example for "Packages for exclude" user input
  Before:

  ```
  :: Packages to exclude: 
  ```
  After:
  ```
  :: Packages to exclude: (eg: "1 2 3", "1-3")
  ```

* Added a new line after user input in function `input()`
  This is pretty visible on a smaller terminal wight
  Before:
  ```
  :: Packages to exclude: (eg: "1 2 3", "1-3") 
  ```
  After:
  ```
  :: Packages to exclude: (eg: "1 2 3", "1-3")
  :: 
  ```
