### PR TITLE
cargo diet: recude crate size on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "http://github.com/Morganamilo/paru"
 documentation = "https://docs.rs/paru"
 license = "GPL-3.0"
 keywords = ["archlinux", "arch", "alpm", "pacman", "aur"]
+include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 
 [dependencies]


### PR DESCRIPTION
| File             | Size (Byte)  |
| -------          | ------------ |
| .gitignore       | 19           |
| dist             | 185          |
| paru.conf        | 383          |
| completions/bash | 4027         |
| help             | 4396         |
| man/paru.conf.5  | 8188         |
| completions/fish | 15081        |
| man/paru.8       | 15162        |
| completions/zsh  | 18336        |

Saved 24% or 65.8 KB in 9 files (of 276.0 KB and 32 files in entire crate)
