### PR TITLE
Added github actions profiles based on Jguer's work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,102 @@
+name: Build Release
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build-releases:
+    strategy:
+      matrix:
+        arch:
+          [
+            "linux/amd64 x86_64",
+            "linux/arm64/v8 aarch64",
+          ]
+    name: Build ${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      - name: Read info
+        id: tags
+        shell: bash
+        run: |
+          arch="${{ matrix.arch }}"
+          echo ::set-output name=PLATFORM::${arch%% *}
+          echo ::set-output name=ARCH::${arch##* }
+      - name: Build ${{ matrix.arch }} release
+        shell: bash
+        run: |
+          arch="${{ matrix.arch }}"
+          PLATFORM=${arch%% *}
+          ARCH=${arch##* }
+          mkdir artifacts
+          docker buildx build --platform $PLATFORM \
+          --tag paru:$ARCH \
+          --load \
+          .
+          docker create --name paru-$ARCH paru:$ARCH
+          docker cp paru-$ARCH:/app/paru.tar.zst paru-$ARCH.tar.zst
+          docker container rm paru-$ARCH
+          mv paru-*.tar.zst artifacts
+      - uses: actions/upload-artifact@v2
+        with:
+          name: paru-${{ steps.tags.outputs.arch }}
+          path: artifacts
+
+  create_release:
+    name: Create release from this build
+    needs: [build-releases]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read info
+        id: tags
+        shell: bash
+        run: |
+          echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+      - uses: actions/download-artifact@v2
+        with:
+          name: paru-x86_64
+      - uses: actions/download-artifact@v2
+        with:
+          name: paru-aarch64
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tags.outputs.tag }}
+          release_name: ${{ steps.tags.outputs.tag }}
+          draft: true
+          prerelease: false
+      - name: Upload x86_64 asset
+        id: upload-release-asset-x86_64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./paru-x86_64.tar.zst
+          asset_name: paru-${{ steps.tags.outputs.tag }}-x86_64.tar.zst
+          asset_content_type: application/tar+zstd
+      - name: Upload aarch64 asset
+        id: upload-release-asset-aarch64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./paru-aarch64.tar.zst
+          asset_name: paru-${{ steps.tags.outputs.tag }}-aarch64.tar.zst
+          asset_content_type: application/tar+zstd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM lopsided/archlinux:devel
+
+WORKDIR /app
+
+COPY ../ .
+
+RUN pacman -Syu --noconfirm rust
+RUN ls -la
+RUN ./dist
+


### PR DESCRIPTION
This adds much-needed automation for release files for both x86_64 and aarch64. This should resolve #117, at least in the sense that the AUR packages will now have paru-bin candidates for aarch64. an issue in the docker/qemu/cargo setup on github/rust/docker's side means that it's not currently possible to get 32 bit ARM builds running, but I have offered (to @Morganamilo) to manually compile these files on a semi-automated way on my own buildserver, and get those files to her to enable earlier than the 3B+ Rasberry pis and other ARM based devices to download binaries at least. 
