### PR TITLE
Change default of BottomUp variable

### DIFF
--- a/paru.conf
+++ b/paru.conf
@@ -13,7 +13,7 @@ PgpFetch
 Devel
 Provides
 DevelSuffixes = -git -cvs -svn -bzr -darcs -always
-#BottomUp
+BottomUp
 #RemoveMake
 #SudoLoop
 #UseAsk


### PR DESCRIPTION
I think that most people will want to use the BottomUp option anyway. So why not change the default?