### PR TITLE
Make sure the script fails when a command fails

### DIFF
--- a/dist
+++ b/dist
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -o errexit -o pipefail
 cargo build --release --locked --target-dir target
 strip target/release/paru
 tar --zstd -cfparu.tar.zst  man completions paru.conf -C target/release paru


### PR DESCRIPTION
By default, shell script will continue to execute the next command even if the previous command exited with non-zero status.