### PR TITLE
man(paru): Remove irrelevant text under entry for --completioninterval

### DIFF
--- a/man/paru.8
+++ b/man/paru.8
@@ -259,8 +259,7 @@ separated list that is quoted by the shell.
 .B \-\-completioninterval <days>
 Time in days to refresh the completion cache. Setting this to 0 will cause the
 cache to be refreshed every time, while setting this to -1 will cause the cache
-to never be re    -c --comments         Print AUR comments for pkgbuild
-freshed. Defaults to 7.
+to never be refreshed. Defaults to 7.
 
 .TP
 .B \-\-sortby <votes|popularity|id|baseid|name|base|submitted|modified>


### PR DESCRIPTION
This mistake seems to have been introduced in e54d6353852d5f9c4b0cdba296d6082e8ff7867c ([file diff](https://github.com/Morganamilo/paru/commit/e54d6353852d5f9c4b0cdba296d6082e8ff7867c#diff-8536eaa31b07ab3d4a95ea757cfebc64f510093c3600ada8422405fb79efee34R262)).