### PR TITLE
Use ubuntu keyserver for pacman gnupg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 COPY ../ .
 
+RUN echo "keyserver hkp://keyserver.ubuntu.com" >> /etc/pacman.d/gnupg/gpg.conf
 RUN pacman -Sy --noconfirm archlinux-keyring
 RUN pacman -Su --noconfirm rust
 RUN ls -la


### PR DESCRIPTION
This should make importing keys more reliable than using the default server. Src: https://wiki.archlinux.org/index.php/Pacman/Package_signing#Change_keyserver