### PR TITLE
Allow user to always or never review

### DIFF
--- a/man/paru.8
+++ b/man/paru.8
@@ -270,8 +270,11 @@ Sort AUR results by a specific field during search. Defaults to votes.
 Search for AUR packages by querying the specified field. Defaults to name-desc.
 
 .TP
-.B \-\-skipreview
+.B \-\-skipreview [= always|never|ask]
 Skip the review process.
+If empty or set to always it will always skip the review process without prompting the user for input.
+If set to never it will always perform the review process without prompting the user for input.
+If set to ask it will ask the user if it wants to skip the review process.
 
 .TP
 .B \-\-review

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -204,8 +204,12 @@ Build packages in a chroot. This rquires the LocalRepo option to be enabled.
 Optionaly a directory may be passed to specify where the create the chroot.
 
 .TP
-.B SkipReview
+.B SkipReview [= always|never|ask]
 Skip the review process.
+If not set it defaults to ask.
+If empty or set to always it will always skip the review process without prompting the user for input.
+If set to never it will always perform the review process without prompting the user for input.
+If set to ask it will ask the user if it wants to skip the review process.
 
 .SH BIN
 Options belonging to the [bin] section.

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -141,6 +141,7 @@ impl Config {
             "makedepends",
             "optdepends",
         ];
+        let always_never_ask = &["always", "never", "ask"];
 
         match takes_value(arg) {
             TakesValue::Required if value.is_none() => bail!("option {} expects a value", arg),
@@ -232,8 +233,10 @@ impl Config {
                 self.aur_filter = true;
             }
             Arg::Long("repo") => self.mode = "repo".to_string(),
-            Arg::Long("skipreview") => self.skip_review = true,
-            Arg::Long("review") => self.skip_review = false,
+            Arg::Long("review") => self.skip_review = "never".to_string(),
+            Arg::Long("skipreview") => {
+                self.skip_review = validate(value.unwrap_or("always"), always_never_ask)?
+            }
             Arg::Long("gendb") => self.gendb = true,
             Arg::Long("nocheck") => self.no_check = true,
             Arg::Long("devel") => self.devel = true,
@@ -363,6 +366,7 @@ fn takes_value(arg: Arg) -> TakesValue {
         Arg::Long("develsuffixes") => TakesValue::Required,
         Arg::Long("localrepo") => TakesValue::Optional,
         Arg::Long("chroot") => TakesValue::Optional,
+        Arg::Long("skipreview") => TakesValue::Optional,
         //pacman
         Arg::Long("dbpath") | Arg::Short('b') => TakesValue::Required,
         Arg::Long("root") | Arg::Short('r') => TakesValue::Required,

--- a/src/config.rs
+++ b/src/config.rs
@@ -189,6 +189,8 @@ pub struct Config {
     #[default = "any"]
     pub mode: String,
     pub aur_filter: bool,
+    #[default = "ask"]
+    pub skip_review: String,
 
     #[default = 7]
     pub completion_interval: u64,
@@ -196,7 +198,6 @@ pub struct Config {
     pub help: bool,
     pub version: bool,
 
-    pub skip_review: bool,
     pub no_check: bool,
     pub no_confirm: bool,
     pub devel: bool,
@@ -636,12 +637,12 @@ impl Config {
             "makedepends",
             "optdepends",
         ];
+        let always_never_ask = &["always", "never", "ask"];
 
         let mut ok1 = true;
         let mut ok2 = true;
 
         match key {
-            "SkipReview" => self.skip_review = true,
             "BottomUp" => self.sort_mode = "bottomup".into(),
             "AurOnly" => self.mode = "aur".into(),
             "RepoOnly" => self.mode = "repo".into(),
@@ -686,6 +687,10 @@ impl Config {
                 let value = value.unwrap_or("yes").into();
                 self.remove_make = validate(value, yes_no_ask)?;
             }
+            "SkipReview" => {
+                let value = value.unwrap_or("always").into();
+                self.skip_review = validate(value, always_never_ask)?;
+            }
             "UpgradeMenu" => self.upgrade_menu = true,
             "LocalRepo" => self.repos = LocalRepos::new(value),
             "Chroot" => {
@@ -716,6 +721,7 @@ impl Config {
             "Redownload" => self.redownload = validate(value?, no_all)?,
             "Rebuild" => self.rebuild = validate(value?, no_all)?,
             "RemoveMake" => self.remove_make = validate(value?, yes_no_ask)?,
+            "SkipReview" => self.skip_review = validate(value?, always_never_ask)?,
             "SortBy" => self.sort_by = validate(value?, sort_by)?,
             "SearchBy" => self.search_by = validate(value?, search_by)?,
             "CompletionInterval" => self.completion_interval = value?.parse()?,

--- a/src/util.rs
+++ b/src/util.rs
@@ -101,6 +101,32 @@ pub fn ask(config: &Config, question: &str, default: bool) -> bool {
     }
 }
 
+pub fn ask_review(config: &Config) -> bool {
+    let action = config.color.action;
+    let bold = config.color.bold;
+    let yn = "[Y/n]:";
+    print!(
+        "{} {} {} ",
+        action.paint("::"),
+        bold.paint("Review diffs?"),
+        bold.paint(yn)
+    );
+    let _ = stdout().lock().flush();
+    let stdin = stdin();
+    let mut input = String::new();
+    let _ = stdin.read_line(&mut input);
+    let input = input.to_lowercase();
+    let input = input.trim();
+
+    if input == "y" || input == "yes" {
+        true
+    } else if input == "n" || input == "no" {
+        false
+    } else {
+        true
+    }
+}
+
 pub fn input(config: &Config, question: &str) -> String {
     let action = config.color.action;
     let bold = config.color.bold;


### PR DESCRIPTION
This modifies the `SkipReview` option to allow the user to set it to `always`, `never` and `ask`.

If set to `ask` it will ask the user if it wants to skip the review process.
If set to `always` or `never` it will always or never show the review process, without ever prompting the user for input.