### PR TITLE
Fix ignore of .SRCINFO during initial review

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -657,7 +657,7 @@ fn review<'a>(
                             {
                                 continue;
                             }
-                            if file.file_type()?.is_dir()
+                            if file.file_type()?.is_file()
                                 && file.path().file_name() == Some(OsStr::new(".SRCINFO"))
                             {
                                 continue;


### PR DESCRIPTION
.SRCINFO is being displayed during the initial review after 9830c7478b1a8f8b1714e0c9cbdc8da516ab8630, this corrects the if.