### PR TITLE
Fixed a typo in zsh completion file

### DIFF
--- a/completions/zsh
+++ b/completions/zsh
@@ -102,8 +102,8 @@ _pacman_opts_common=(
 	"--nochroot[Don't build packages in a chroot]"
 	'--localrepo[Build packages in a local repo]'
 
-	'--upgrademenu[Skip the review process]'
-	"--upgrademenu[Don't skip the review process]"
+	'--skipreview[Skip the review process]'
+	"--review[Don't skip the review process]"
 )
 
 # options for passing to _arguments: options for --upgrade commands


### PR DESCRIPTION
Looks like there was a typo made in a6c85111e4d0437652c7ae570622ce38d9aa431b when adding zsh completion.