### PR TITLE
Use enums instead of strings for most values in the Config struct.

### DIFF
--- a/src/clean.rs
+++ b/src/clean.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{Config, CfgMode};
 
 use crate::exec;
 use crate::print_error;
@@ -15,11 +15,11 @@ use anyhow::{bail, Context, Result};
 use srcinfo::Srcinfo;
 
 pub fn clean(config: &Config) -> Result<()> {
-    if config.mode != "aur" {
+    if config.mode != CfgMode::Aur {
         exec::pacman(config, &config.args)?;
     }
 
-    if config.mode != "repo" {
+    if config.mode != CfgMode::Repo {
         let remove_all = config.delete;
         let clean_method = &config.pacman.clean_method;
         let keep_installed = clean_method.iter().any(|a| a == "KeepInstalled");
@@ -31,7 +31,7 @@ pub fn clean(config: &Config) -> Result<()> {
             "Do you want to remove all other AUR packages from cache?"
         };
 
-        if config.mode == "any" {
+        if config.mode == CfgMode::Any {
             println!();
         }
 

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, CfgMode};
+use crate::config::{Config, Mode};
 
 use crate::exec;
 use crate::print_error;
@@ -15,11 +15,11 @@ use anyhow::{bail, Context, Result};
 use srcinfo::Srcinfo;
 
 pub fn clean(config: &Config) -> Result<()> {
-    if config.mode != CfgMode::Aur {
+    if config.mode != Mode::Aur {
         exec::pacman(config, &config.args)?;
     }
 
-    if config.mode != CfgMode::Repo {
+    if config.mode != Mode::Repo {
         let remove_all = config.delete;
         let clean_method = &config.pacman.clean_method;
         let keep_installed = clean_method.iter().any(|a| a == "KeepInstalled");
@@ -31,7 +31,7 @@ pub fn clean(config: &Config) -> Result<()> {
             "Do you want to remove all other AUR packages from cache?"
         };
 
-        if config.mode == CfgMode::Any {
+        if config.mode == Mode::Any {
             println!();
         }
 

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -1,6 +1,6 @@
 use crate::args::{PACMAN_FLAGS, PACMAN_GLOBALS};
 use crate::config::{
-    CfgEnum, CfgMode, CfgOp, CfgSortMode, CfgYesNoAll, CfgYesNoAsk, Colors, Config, LocalRepos,
+    Colors, Config, ConfigEnum, LocalRepos, Mode, Op, SortMode, YesNoAll, YesNoAsk,
 };
 
 use std::fmt;
@@ -149,7 +149,7 @@ impl Config {
             });
         }
 
-        let mut set_op = |op: CfgOp| {
+        let mut set_op = |op: Op| {
             self.op = op;
             *op_count += 1;
         };
@@ -192,32 +192,30 @@ impl Config {
                     .parse()
                     .map_err(|_| anyhow!("option {} must be a number", arg))?
             }
-            Arg::Long("sortby") => self.sort_by = CfgEnum::from_str_validate(argkey, value?)?,
-            Arg::Long("searchby") => self.search_by = CfgEnum::from_str_validate(argkey, value?)?,
+            Arg::Long("sortby") => self.sort_by = ConfigEnum::from_str(argkey, value?)?,
+            Arg::Long("searchby") => self.search_by = ConfigEnum::from_str(argkey, value?)?,
             Arg::Long("news") | Arg::Short('w') => self.news += 1,
             Arg::Long("removemake") => {
-                self.remove_make = CfgYesNoAsk::Yes.from_str_validate_or(argkey, value.ok())?
+                self.remove_make = YesNoAsk::Yes.default_or(argkey, value.ok())?
             }
             Arg::Long("upgrademenu") => self.upgrade_menu = true,
             Arg::Long("noupgrademenu") => self.upgrade_menu = false,
-            Arg::Long("noremovemake") => self.remove_make = CfgYesNoAsk::No,
+            Arg::Long("noremovemake") => self.remove_make = YesNoAsk::No,
             Arg::Long("cleanafter") => self.clean_after = true,
             Arg::Long("nocleanafter") => self.clean_after = false,
             Arg::Long("redownload") => {
-                self.redownload = CfgYesNoAll::Yes.from_str_validate_or(argkey, value.ok())?
+                self.redownload = YesNoAll::Yes.default_or(argkey, value.ok())?
             }
-            Arg::Long("noredownload") => self.redownload = CfgYesNoAll::No,
-            Arg::Long("rebuild") => {
-                self.rebuild = CfgYesNoAll::Yes.from_str_validate_or(argkey, value.ok())?
-            }
-            Arg::Long("norebuild") => self.rebuild = CfgYesNoAll::No,
-            Arg::Long("topdown") => self.sort_mode = CfgSortMode::TopDown,
-            Arg::Long("bottomup") => self.sort_mode = CfgSortMode::BottomUp,
+            Arg::Long("noredownload") => self.redownload = YesNoAll::No,
+            Arg::Long("rebuild") => self.rebuild = YesNoAll::Yes.default_or(argkey, value.ok())?,
+            Arg::Long("norebuild") => self.rebuild = YesNoAll::No,
+            Arg::Long("topdown") => self.sort_mode = SortMode::TopDown,
+            Arg::Long("bottomup") => self.sort_mode = SortMode::BottomUp,
             Arg::Long("aur") | Arg::Short('a') => {
-                self.mode = CfgMode::Aur;
+                self.mode = Mode::Aur;
                 self.aur_filter = true;
             }
-            Arg::Long("repo") => self.mode = CfgMode::Repo,
+            Arg::Long("repo") => self.mode = Mode::Repo,
             Arg::Long("skipreview") => self.skip_review = true,
             Arg::Long("review") => self.skip_review = false,
             Arg::Long("gendb") => self.gendb = true,
@@ -260,17 +258,17 @@ impl Config {
             Arg::Long("nonewsonupgrade") => self.news_on_upgrade = false,
             Arg::Long("comments") => self.comments = true,
             // ops
-            Arg::Long("database") | Arg::Short('D') => set_op(CfgOp::Database),
-            Arg::Long("files") | Arg::Short('F') => set_op(CfgOp::Files),
-            Arg::Long("query") | Arg::Short('Q') => set_op(CfgOp::Query),
-            Arg::Long("remove") | Arg::Short('R') => set_op(CfgOp::Remove),
-            Arg::Long("sync") | Arg::Short('S') => set_op(CfgOp::Sync),
-            Arg::Long("deptest") | Arg::Short('T') => set_op(CfgOp::DepTest),
-            Arg::Long("upgrade") | Arg::Short('U') => set_op(CfgOp::Upgrade),
-            Arg::Long("show") | Arg::Short('P') => set_op(CfgOp::Show),
-            Arg::Long("getpkgbuild") | Arg::Short('G') => set_op(CfgOp::GetPkgBuild),
-            Arg::Long("repoctl") | Arg::Short('L') => set_op(CfgOp::RepoCtl),
-            Arg::Long("chrootctl") | Arg::Short('C') => set_op(CfgOp::ChrootCtl),
+            Arg::Long("database") | Arg::Short('D') => set_op(Op::Database),
+            Arg::Long("files") | Arg::Short('F') => set_op(Op::Files),
+            Arg::Long("query") | Arg::Short('Q') => set_op(Op::Query),
+            Arg::Long("remove") | Arg::Short('R') => set_op(Op::Remove),
+            Arg::Long("sync") | Arg::Short('S') => set_op(Op::Sync),
+            Arg::Long("deptest") | Arg::Short('T') => set_op(Op::DepTest),
+            Arg::Long("upgrade") | Arg::Short('U') => set_op(Op::Upgrade),
+            Arg::Long("show") | Arg::Short('P') => set_op(Op::Show),
+            Arg::Long("getpkgbuild") | Arg::Short('G') => set_op(Op::GetPkgBuild),
+            Arg::Long("repoctl") | Arg::Short('L') => set_op(Op::RepoCtl),
+            Arg::Long("chrootctl") | Arg::Short('C') => set_op(Op::ChrootCtl),
             // globals
             Arg::Long("noconfirm") => self.no_confirm = true,
             Arg::Long("confirm") => self.no_confirm = false,

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -1,6 +1,6 @@
 use crate::args::{PACMAN_FLAGS, PACMAN_GLOBALS};
 use crate::config::{
-    CfgMode, CfgOp, CfgSortMode, CfgValue, CfgYesNoAll, CfgYesNoAsk, Colors, Config, LocalRepos,
+    CfgEnum, CfgMode, CfgOp, CfgSortMode, CfgYesNoAll, CfgYesNoAsk, Colors, Config, LocalRepos,
 };
 
 use std::fmt;
@@ -192,8 +192,8 @@ impl Config {
                     .parse()
                     .map_err(|_| anyhow!("option {} must be a number", arg))?
             }
-            Arg::Long("sortby") => self.sort_by = CfgValue::from_str_validate(argkey, value?)?,
-            Arg::Long("searchby") => self.search_by = CfgValue::from_str_validate(argkey, value?)?,
+            Arg::Long("sortby") => self.sort_by = CfgEnum::from_str_validate(argkey, value?)?,
+            Arg::Long("searchby") => self.search_by = CfgEnum::from_str_validate(argkey, value?)?,
             Arg::Long("news") | Arg::Short('w') => self.news += 1,
             Arg::Long("removemake") => {
                 self.remove_make = CfgYesNoAsk::Yes.from_str_validate_or(argkey, value.ok())?

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,7 +142,7 @@ impl Colors {
     }
 }
 
-pub trait CfgValue: Sized + PartialEq + Clone + fmt::Debug + 'static {
+pub trait CfgEnum: Sized + PartialEq + Clone + fmt::Debug + 'static {
     const VALUE_LOOKUP: &'static [(&'static str, Self)];
 
     fn as_str(&self) -> &'static str {
@@ -164,7 +164,7 @@ pub trait CfgValue: Sized + PartialEq + Clone + fmt::Debug + 'static {
 
     #[allow(clippy::wrong_self_convention)]
     fn from_str_validate_or(self, key: &str, maybevalue: Option<&str>) -> Result<Self> {
-        maybevalue.map_or(Ok(self), |value| CfgValue::from_str_validate(key, value))
+        maybevalue.map_or(Ok(self), |value| CfgEnum::from_str_validate(key, value))
     }
 
     fn from_str_validate(key: &str, value: &str) -> Result<Self> {
@@ -187,6 +187,8 @@ pub trait CfgValue: Sized + PartialEq + Clone + fmt::Debug + 'static {
     }
 }
 
+type CfgEnumLookupTable<T> = &'static [(&'static str, T)];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CfgOp {
     ChrootCtl,
@@ -203,8 +205,8 @@ pub enum CfgOp {
     Yay,
 }
 
-impl CfgValue for CfgOp {
-    const VALUE_LOOKUP: &'static [(&'static str, Self)] = &[
+impl CfgEnum for CfgOp {
+    const VALUE_LOOKUP: CfgEnumLookupTable<Self> = &[
         ("chrootctl", Self::ChrootCtl),
         ("database", Self::Database),
         ("deptest", Self::DepTest),
@@ -220,8 +222,8 @@ impl CfgValue for CfgOp {
     ];
 }
 
-impl std::fmt::Display for CfgOp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for CfgOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_str())
     }
 }
@@ -238,8 +240,8 @@ pub enum CfgSortBy {
     Votes,
 }
 
-impl CfgValue for CfgSortBy {
-    const VALUE_LOOKUP: &'static [(&'static str, Self)] = &[
+impl CfgEnum for CfgSortBy {
+    const VALUE_LOOKUP: CfgEnumLookupTable<Self> = &[
         ("base", Self::Base),
         ("baseid", Self::BaseId),
         ("id", Self::Id),
@@ -262,8 +264,8 @@ pub enum CfgSearchBy {
     OptDepends,
 }
 
-impl CfgValue for CfgSearchBy {
-    const VALUE_LOOKUP: &'static [(&'static str, Self)] = &[
+impl CfgEnum for CfgSearchBy {
+    const VALUE_LOOKUP: CfgEnumLookupTable<Self> = &[
         ("checkdepends", Self::CheckDepends),
         ("depends", Self::Depends),
         ("maintainer", Self::Maintainer),
@@ -280,8 +282,8 @@ pub enum CfgSortMode {
     TopDown,
 }
 
-impl CfgValue for CfgSortMode {
-    const VALUE_LOOKUP: &'static [(&'static str, Self)] =
+impl CfgEnum for CfgSortMode {
+    const VALUE_LOOKUP: CfgEnumLookupTable<Self> =
         &[("bottomup", Self::BottomUp), ("topdown", Self::TopDown)];
 }
 
@@ -292,8 +294,8 @@ pub enum CfgMode {
     Repo,
 }
 
-impl CfgValue for CfgMode {
-    const VALUE_LOOKUP: &'static [(&'static str, Self)] =
+impl CfgEnum for CfgMode {
+    const VALUE_LOOKUP: CfgEnumLookupTable<Self> =
         &[("any", Self::Any), ("aur", Self::Aur), ("repo", Self::Repo)];
 }
 
@@ -304,8 +306,8 @@ pub enum CfgYesNoAll {
     All,
 }
 
-impl CfgValue for CfgYesNoAll {
-    const VALUE_LOOKUP: &'static [(&'static str, Self)] =
+impl CfgEnum for CfgYesNoAll {
+    const VALUE_LOOKUP: CfgEnumLookupTable<Self> =
         &[("yes", Self::Yes), ("no", Self::No), ("all", Self::All)];
 }
 
@@ -316,8 +318,8 @@ pub enum CfgYesNoAsk {
     Ask,
 }
 
-impl CfgValue for CfgYesNoAsk {
-    const VALUE_LOOKUP: &'static [(&'static str, Self)] =
+impl CfgEnum for CfgYesNoAsk {
+    const VALUE_LOOKUP: CfgEnumLookupTable<Self> =
         &[("yes", Self::Yes), ("no", Self::No), ("ask", Self::Ask)];
 }
 
@@ -868,11 +870,11 @@ impl Config {
         match key {
             "AurUrl" => self.aur_url = value?.parse()?,
             "BuildDir" | "CloneDir" => self.build_dir = PathBuf::from(value?),
-            "Redownload" => self.redownload = CfgValue::from_str_validate(key, value?.as_str())?,
-            "Rebuild" => self.rebuild = CfgValue::from_str_validate(key, value?.as_str())?,
-            "RemoveMake" => self.remove_make = CfgValue::from_str_validate(key, value?.as_str())?,
-            "SortBy" => self.sort_by = CfgValue::from_str_validate(key, value?.as_str())?,
-            "SearchBy" => self.search_by = CfgValue::from_str_validate(key, value?.as_str())?,
+            "Redownload" => self.redownload = CfgEnum::from_str_validate(key, value?.as_str())?,
+            "Rebuild" => self.rebuild = CfgEnum::from_str_validate(key, value?.as_str())?,
+            "RemoveMake" => self.remove_make = CfgEnum::from_str_validate(key, value?.as_str())?,
+            "SortBy" => self.sort_by = CfgEnum::from_str_validate(key, value?.as_str())?,
+            "SearchBy" => self.search_by = CfgEnum::from_str_validate(key, value?.as_str())?,
             "CompletionInterval" => self.completion_interval = value?.parse()?,
             "PacmanConf" => self.pacman_conf = Some(value?),
             _ => ok2 = false,

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,4 +1,4 @@
-use crate::config::{Colors, Config, CfgYesNoAll, CfgSortMode, CfgMode};
+use crate::config::{Colors, Config, YesNoAll, SortMode, Mode};
 use crate::fmt::print_indent;
 
 use std::collections::{HashMap, HashSet};
@@ -341,7 +341,7 @@ pub async fn new_aur_pkgbuilds(
     srcinfos: &HashMap<String, Srcinfo>,
 ) -> Result<()> {
     let mut pkgs = Vec::new();
-    if config.redownload == CfgYesNoAll::All {
+    if config.redownload == YesNoAll::All {
         return aur_pkgbuilds(config, bases).await;
     }
 
@@ -400,7 +400,7 @@ pub async fn show_comments(config: &mut Config) -> Result<i32> {
 
         let iter = titles.zip(comments).collect::<Vec<_>>();
 
-        if config.sort_mode == CfgSortMode::TopDown {
+        if config.sort_mode == SortMode::TopDown {
             for (title, comment) in iter.into_iter() {
                 println!("{}", c.bold.paint(title.trim()));
 
@@ -437,9 +437,9 @@ fn split_repo_aur_pkgbuilds<'a, T: AsTarg>(
 
     for targ in targets {
         let targ = targ.as_targ();
-        if config.mode == CfgMode::Aur {
+        if config.mode == Mode::Aur {
             aur.push(targ);
-        } else if config.mode == CfgMode::Repo {
+        } else if config.mode == Mode::Repo {
             local.push(targ);
         } else if let Some(repo) = targ.repo {
             if matches!(

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,4 +1,4 @@
-use crate::config::{Colors, Config};
+use crate::config::{Colors, Config, CfgYesNoAll, CfgSortMode, CfgMode};
 use crate::fmt::print_indent;
 
 use std::collections::{HashMap, HashSet};
@@ -341,7 +341,7 @@ pub async fn new_aur_pkgbuilds(
     srcinfos: &HashMap<String, Srcinfo>,
 ) -> Result<()> {
     let mut pkgs = Vec::new();
-    if config.redownload == "all" {
+    if config.redownload == CfgYesNoAll::All {
         return aur_pkgbuilds(config, bases).await;
     }
 
@@ -400,7 +400,7 @@ pub async fn show_comments(config: &mut Config) -> Result<i32> {
 
         let iter = titles.zip(comments).collect::<Vec<_>>();
 
-        if config.sort_mode == "topdown" {
+        if config.sort_mode == CfgSortMode::TopDown {
             for (title, comment) in iter.into_iter() {
                 println!("{}", c.bold.paint(title.trim()));
 
@@ -437,9 +437,9 @@ fn split_repo_aur_pkgbuilds<'a, T: AsTarg>(
 
     for targ in targets {
         let targ = targ.as_targ();
-        if config.mode == "aur" {
+        if config.mode == CfgMode::Aur {
             aur.push(targ);
-        } else if config.mode == "repo" {
+        } else if config.mode == CfgMode::Repo {
             local.push(targ);
         } else if let Some(repo) = targ.repo {
             if matches!(

--- a/src/install.rs
+++ b/src/install.rs
@@ -2,7 +2,7 @@ use crate::args::Arg;
 use crate::chroot::Chroot;
 use crate::clean::clean_untracked;
 use crate::completion::update_aur_cache;
-use crate::config::{Config, LocalRepos};
+use crate::config::{CfgMode, CfgOp, CfgYesNoAll, CfgYesNoAsk, Config, LocalRepos};
 use crate::devel::{fetch_devel_info, load_devel_info, save_devel_info, DevelInfo};
 use crate::download::{self, Bases};
 use crate::fmt::{color_repo, print_indent};
@@ -135,9 +135,7 @@ pub async fn build_pkgbuild(config: &mut Config) -> Result<i32> {
         exec::spawn_sudo(config.sudo_bin.clone(), config.sudo_loop.clone())?;
     }
 
-    config.op = "sync".to_string();
-    config.args.op = config.op.clone();
-    config.globals.op = config.op.clone();
+    config.set_op_args_globals(CfgOp::Sync);
 
     let flags = flags(config);
     let resolver = resolver(&config, &config.alpm, &config.raur, &mut cache, flags);
@@ -315,9 +313,7 @@ pub async fn install(config: &mut Config, targets_str: &[String]) -> Result<i32>
         }
     }
 
-    config.op = "sync".to_string();
-    config.args.op = config.op.clone();
-    config.globals.op = config.op.clone();
+    config.set_op_args_globals(CfgOp::Sync);
     config.targets = targets_str.to_vec();
     config.args.targets = config.targets.clone();
 
@@ -332,7 +328,7 @@ pub async fn install(config: &mut Config, targets_str: &[String]) -> Result<i32>
         bail!("no targets specified (use -h for help)");
     }
 
-    if config.mode != "aur" {
+    if config.mode != CfgMode::Aur {
         if config.combined_upgrade {
             if config.args.has_arg("y", "refresh") {
                 early_refresh(config)?;
@@ -456,10 +452,10 @@ async fn prepare_build<'a>(
     let has_make = if !config.chroot
         && (actions.iter_build_pkgs().any(|p| p.make) || actions.install.iter().any(|p| p.make))
     {
-        if config.remove_make == "ask" {
+        if config.remove_make == CfgYesNoAsk::Ask {
             ask(config, "Remove make dependencies after install?", false)
         } else {
-            config.remove_make == "yes"
+            config.remove_make == CfgYesNoAsk::Yes
         }
     } else {
         false
@@ -827,7 +823,7 @@ fn repo_install(config: &Config, install: &[RepoPackage]) -> Result<i32> {
         .remove("refresh");
     args.targets = targets.iter().map(|s| s.as_str()).collect();
 
-    if !config.combined_upgrade || config.mode == "aur" {
+    if !config.combined_upgrade || config.mode == CfgMode::Aur {
         args.remove("u").remove("sysupgrade");
     }
 
@@ -1555,16 +1551,16 @@ fn flags(config: &mut Config) -> aur_depends::Flags {
         flags.remove(Flags::CHECK_DEPENDS);
         config.mflags.push("--nocheck".into());
     }
-    if config.mode == "aur" {
+    if config.mode == CfgMode::Aur {
         flags |= Flags::AUR_ONLY;
     }
-    if config.mode == "repo" {
+    if config.mode == CfgMode::Repo {
         flags |= Flags::REPO_ONLY;
     }
     if !config.provides {
         flags.remove(Flags::TARGET_PROVIDES | Flags::MISSING_PROVIDES);
     }
-    if config.op == "yay" {
+    if config.op == CfgOp::Yay {
         flags.remove(Flags::TARGET_PROVIDES);
     }
     if config.repos != LocalRepos::None {
@@ -1680,7 +1676,7 @@ fn is_debug(pkg: alpm::Package) -> bool {
 fn print_warnings(config: &Config, cache: &Cache, actions: Option<&Actions>) {
     let mut warnings = crate::download::Warnings::default();
 
-    if config.mode == "repo" {
+    if config.mode == CfgMode::Repo {
         return;
     }
 
@@ -1764,7 +1760,9 @@ fn needs_build(
     pkgdest: &HashMap<String, String>,
     version: &str,
 ) -> bool {
-    if (config.rebuild == "yes" && base.pkgs.iter().any(|p| p.target)) || config.rebuild == "all" {
+    if (config.rebuild == CfgYesNoAll::Yes && base.pkgs.iter().any(|p| p.target))
+        || config.rebuild == CfgYesNoAll::All
+    {
         return true;
     }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -2,7 +2,7 @@ use crate::args::Arg;
 use crate::chroot::Chroot;
 use crate::clean::clean_untracked;
 use crate::completion::update_aur_cache;
-use crate::config::{CfgMode, CfgOp, CfgYesNoAll, CfgYesNoAsk, Config, LocalRepos};
+use crate::config::{Mode, Op, YesNoAll, YesNoAsk, Config, LocalRepos};
 use crate::devel::{fetch_devel_info, load_devel_info, save_devel_info, DevelInfo};
 use crate::download::{self, Bases};
 use crate::fmt::{color_repo, print_indent};
@@ -135,7 +135,7 @@ pub async fn build_pkgbuild(config: &mut Config) -> Result<i32> {
         exec::spawn_sudo(config.sudo_bin.clone(), config.sudo_loop.clone())?;
     }
 
-    config.set_op_args_globals(CfgOp::Sync);
+    config.set_op_args_globals(Op::Sync);
 
     let flags = flags(config);
     let resolver = resolver(&config, &config.alpm, &config.raur, &mut cache, flags);
@@ -313,7 +313,7 @@ pub async fn install(config: &mut Config, targets_str: &[String]) -> Result<i32>
         }
     }
 
-    config.set_op_args_globals(CfgOp::Sync);
+    config.set_op_args_globals(Op::Sync);
     config.targets = targets_str.to_vec();
     config.args.targets = config.targets.clone();
 
@@ -328,7 +328,7 @@ pub async fn install(config: &mut Config, targets_str: &[String]) -> Result<i32>
         bail!("no targets specified (use -h for help)");
     }
 
-    if config.mode != CfgMode::Aur {
+    if config.mode != Mode::Aur {
         if config.combined_upgrade {
             if config.args.has_arg("y", "refresh") {
                 early_refresh(config)?;
@@ -452,10 +452,10 @@ async fn prepare_build<'a>(
     let has_make = if !config.chroot
         && (actions.iter_build_pkgs().any(|p| p.make) || actions.install.iter().any(|p| p.make))
     {
-        if config.remove_make == CfgYesNoAsk::Ask {
+        if config.remove_make == YesNoAsk::Ask {
             ask(config, "Remove make dependencies after install?", false)
         } else {
-            config.remove_make == CfgYesNoAsk::Yes
+            config.remove_make == YesNoAsk::Yes
         }
     } else {
         false
@@ -823,7 +823,7 @@ fn repo_install(config: &Config, install: &[RepoPackage]) -> Result<i32> {
         .remove("refresh");
     args.targets = targets.iter().map(|s| s.as_str()).collect();
 
-    if !config.combined_upgrade || config.mode == CfgMode::Aur {
+    if !config.combined_upgrade || config.mode == Mode::Aur {
         args.remove("u").remove("sysupgrade");
     }
 
@@ -1551,16 +1551,16 @@ fn flags(config: &mut Config) -> aur_depends::Flags {
         flags.remove(Flags::CHECK_DEPENDS);
         config.mflags.push("--nocheck".into());
     }
-    if config.mode == CfgMode::Aur {
+    if config.mode == Mode::Aur {
         flags |= Flags::AUR_ONLY;
     }
-    if config.mode == CfgMode::Repo {
+    if config.mode == Mode::Repo {
         flags |= Flags::REPO_ONLY;
     }
     if !config.provides {
         flags.remove(Flags::TARGET_PROVIDES | Flags::MISSING_PROVIDES);
     }
-    if config.op == CfgOp::Yay {
+    if config.op == Op::Yay {
         flags.remove(Flags::TARGET_PROVIDES);
     }
     if config.repos != LocalRepos::None {
@@ -1676,7 +1676,7 @@ fn is_debug(pkg: alpm::Package) -> bool {
 fn print_warnings(config: &Config, cache: &Cache, actions: Option<&Actions>) {
     let mut warnings = crate::download::Warnings::default();
 
-    if config.mode == CfgMode::Repo {
+    if config.mode == Mode::Repo {
         return;
     }
 
@@ -1760,8 +1760,8 @@ fn needs_build(
     pkgdest: &HashMap<String, String>,
     version: &str,
 ) -> bool {
-    if (config.rebuild == CfgYesNoAll::Yes && base.pkgs.iter().any(|p| p.target))
-        || config.rebuild == CfgYesNoAll::All
+    if (config.rebuild == YesNoAll::Yes && base.pkgs.iter().any(|p| p.target))
+        || config.rebuild == YesNoAll::All
     {
         return true;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ mod util;
 extern crate smart_default;
 
 use crate::chroot::Chroot;
-use crate::config::{Config, CfgOp};
+use crate::config::{Config, Op};
 use crate::query::print_upgrade_list;
 
 use std::collections::HashMap;
@@ -114,24 +114,24 @@ async fn run(config: &mut Config) -> Result<i32> {
 }
 
 async fn handle_cmd(config: &mut Config) -> Result<i32> {
-    if config.op == CfgOp::ChrootCtl || config.chroot {
+    if config.op == Op::ChrootCtl || config.chroot {
         if Command::new("arch-nspawn").arg("-h").output().is_err() {
             bail!("can not use chroot builds: devtools is not installed");
         }
     }
 
     let ret = match config.op {
-        CfgOp::Database | CfgOp::Files => exec::pacman(config, &config.args)?.code(),
-        CfgOp::Upgrade => handle_upgrade(config).await?,
-        CfgOp::Query => handle_query(config).await?,
-        CfgOp::Sync => handle_sync(config).await?,
-        CfgOp::Remove => handle_remove(config)?,
-        CfgOp::DepTest => handle_test(config).await?,
-        CfgOp::GetPkgBuild => handle_get_pkg_build(config).await?,
-        CfgOp::Show => handle_show(config).await?,
-        CfgOp::Yay => handle_yay(config).await?,
-        CfgOp::RepoCtl => handle_repo(config)?,
-        CfgOp::ChrootCtl => handle_chroot(config)?,
+        Op::Database | Op::Files => exec::pacman(config, &config.args)?.code(),
+        Op::Upgrade => handle_upgrade(config).await?,
+        Op::Query => handle_query(config).await?,
+        Op::Sync => handle_sync(config).await?,
+        Op::Remove => handle_remove(config)?,
+        Op::DepTest => handle_test(config).await?,
+        Op::GetPkgBuild => handle_get_pkg_build(config).await?,
+        Op::Show => handle_show(config).await?,
+        Op::Yay => handle_yay(config).await?,
+        Op::RepoCtl => handle_repo(config)?,
+        Op::ChrootCtl => handle_chroot(config)?,
         // _ => bail!("unknown op '{}'", config.op),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ mod util;
 extern crate smart_default;
 
 use crate::chroot::Chroot;
-use crate::config::Config;
+use crate::config::{Config, CfgOp};
 use crate::query::print_upgrade_list;
 
 use std::collections::HashMap;
@@ -114,25 +114,25 @@ async fn run(config: &mut Config) -> Result<i32> {
 }
 
 async fn handle_cmd(config: &mut Config) -> Result<i32> {
-    if config.op == "chrootctl" || config.chroot {
+    if config.op == CfgOp::ChrootCtl || config.chroot {
         if Command::new("arch-nspawn").arg("-h").output().is_err() {
             bail!("can not use chroot builds: devtools is not installed");
         }
     }
 
-    let ret = match config.op.as_str() {
-        "database" | "files" => exec::pacman(config, &config.args)?.code(),
-        "upgrade" => handle_upgrade(config).await?,
-        "query" => handle_query(config).await?,
-        "sync" => handle_sync(config).await?,
-        "remove" => handle_remove(config)?,
-        "deptest" => handle_test(config).await?,
-        "getpkgbuild" => handle_get_pkg_build(config).await?,
-        "show" => handle_show(config).await?,
-        "yay" => handle_yay(config).await?,
-        "repoctl" => handle_repo(config)?,
-        "chrootctl" => handle_chroot(config)?,
-        _ => bail!("unknown op '{}'", config.op),
+    let ret = match config.op {
+        CfgOp::Database | CfgOp::Files => exec::pacman(config, &config.args)?.code(),
+        CfgOp::Upgrade => handle_upgrade(config).await?,
+        CfgOp::Query => handle_query(config).await?,
+        CfgOp::Sync => handle_sync(config).await?,
+        CfgOp::Remove => handle_remove(config)?,
+        CfgOp::DepTest => handle_test(config).await?,
+        CfgOp::GetPkgBuild => handle_get_pkg_build(config).await?,
+        CfgOp::Show => handle_show(config).await?,
+        CfgOp::Yay => handle_yay(config).await?,
+        CfgOp::RepoCtl => handle_repo(config)?,
+        CfgOp::ChrootCtl => handle_chroot(config)?,
+        // _ => bail!("unknown op '{}'", config.op),
     };
 
     Ok(ret)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::config::{Config, LocalRepos};
+use crate::config::{Config, CfgMode, LocalRepos};
 use crate::devel::{filter_devel_updates, possible_devel_updates};
 use crate::util::split_repo_aur_pkgs;
 use crate::{exec, repo};
@@ -16,9 +16,9 @@ pub async fn print_upgrade_list(config: &mut Config) -> Result<i32> {
     let args = &config.args;
 
     if args.has_arg("n", "native") {
-        config.mode = "repo".into();
+        config.mode = CfgMode::Repo;
     } else if args.has_arg("m", "foreign") {
-        config.mode = "aur".into();
+        config.mode = CfgMode::Aur;
     }
 
     let targets: Vec<_> = if config.targets.is_empty() {
@@ -54,13 +54,13 @@ pub async fn print_upgrade_list(config: &mut Config) -> Result<i32> {
     let mut repo_ret = 1;
     let mut aur_ret = 1;
 
-    if !repo.is_empty() && config.mode != "aur" {
+    if !repo.is_empty() && config.mode != CfgMode::Aur {
         let mut args = config.pacman_args();
         args.targets = repo.into_iter().collect();
         repo_ret = exec::pacman(config, &args)?.code();
     }
 
-    if !aur.is_empty() && config.mode != "repo" {
+    if !aur.is_empty() && config.mode != CfgMode::Repo {
         let bold = config.color.bold;
         let error = config.color.error;
         let upgrade = config.color.upgrade;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::config::{Config, CfgMode, LocalRepos};
+use crate::config::{Config, Mode, LocalRepos};
 use crate::devel::{filter_devel_updates, possible_devel_updates};
 use crate::util::split_repo_aur_pkgs;
 use crate::{exec, repo};
@@ -16,9 +16,9 @@ pub async fn print_upgrade_list(config: &mut Config) -> Result<i32> {
     let args = &config.args;
 
     if args.has_arg("n", "native") {
-        config.mode = CfgMode::Repo;
+        config.mode = Mode::Repo;
     } else if args.has_arg("m", "foreign") {
-        config.mode = CfgMode::Aur;
+        config.mode = Mode::Aur;
     }
 
     let targets: Vec<_> = if config.targets.is_empty() {
@@ -54,13 +54,13 @@ pub async fn print_upgrade_list(config: &mut Config) -> Result<i32> {
     let mut repo_ret = 1;
     let mut aur_ret = 1;
 
-    if !repo.is_empty() && config.mode != CfgMode::Aur {
+    if !repo.is_empty() && config.mode != Mode::Aur {
         let mut args = config.pacman_args();
         args.targets = repo.into_iter().collect();
         repo_ret = exec::pacman(config, &args)?.code();
     }
 
-    if !aur.is_empty() && config.mode != CfgMode::Repo {
+    if !aur.is_empty() && config.mode != Mode::Repo {
         let bold = config.color.bold;
         let error = config.color.error;
         let upgrade = config.color.upgrade;

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{Config, CfgSearchBy, CfgSortMode, CfgMode};
 use crate::fmt::{color_repo, print_indent};
 use crate::info;
 use crate::install::install;
@@ -8,6 +8,8 @@ use ansi_term::Style;
 use anyhow::{Context, Result};
 use indicatif::HumanBytes;
 use raur::{Raur, SearchBy};
+
+use crate::config::CfgSortBy;
 
 enum AnyPkg<'a> {
     RepoPkg(alpm::Package<'a>),
@@ -28,7 +30,7 @@ pub async fn search(config: &Config) -> Result<i32> {
         .await
         .context("aur search failed")?;
 
-    if config.sort_mode == "topdown" {
+    if config.sort_mode == CfgSortMode::TopDown {
         for pkg in &repo_pkgs {
             print_alpm_pkg(config, pkg, quiet);
         }
@@ -48,7 +50,7 @@ pub async fn search(config: &Config) -> Result<i32> {
 }
 
 fn search_repos<'a>(config: &'a Config, targets: &[String]) -> Result<Vec<alpm::Package<'a>>> {
-    if targets.is_empty() || config.mode == "aur" {
+    if targets.is_empty() || config.mode == CfgMode::Aur {
         return Ok(Vec::new());
     }
 
@@ -63,19 +65,19 @@ fn search_repos<'a>(config: &'a Config, targets: &[String]) -> Result<Vec<alpm::
 }
 
 async fn search_aur(config: &Config, targets: &[String]) -> Result<Vec<raur::Package>> {
-    if targets.is_empty() || config.mode == "repo" {
+    if targets.is_empty() || config.mode == CfgMode::Repo {
         return Ok(Vec::new());
     }
 
     let mut matches = Vec::new();
 
-    let by = match config.search_by.as_str() {
-        "name" => SearchBy::Name,
-        "maintainer" => SearchBy::Maintainer,
-        "depends" => SearchBy::Depends,
-        "makedepends" => SearchBy::MakeDepends,
-        "checkdepends" => SearchBy::CheckDepends,
-        "optdepends" => SearchBy::OptDepends,
+    let by = match config.search_by {
+        CfgSearchBy::Name => SearchBy::Name,
+        CfgSearchBy::Maintainer => SearchBy::Maintainer,
+        CfgSearchBy::Depends => SearchBy::Depends,
+        CfgSearchBy::MakeDepends => SearchBy::MakeDepends,
+        CfgSearchBy::CheckDepends => SearchBy::CheckDepends,
+        CfgSearchBy::OptDepends => SearchBy::OptDepends,
         _ => SearchBy::NameDesc,
     };
 
@@ -114,14 +116,14 @@ async fn search_aur(config: &Config, targets: &[String]) -> Result<Vec<raur::Pac
         }
     }
 
-    match config.sort_by.as_str() {
-        "votes" => matches.sort_by(|a, b| b.num_votes.cmp(&a.num_votes)),
-        "popularity" => matches.sort_by(|a, b| b.popularity.partial_cmp(&a.popularity).unwrap()),
-        "id" => matches.sort_by_key(|p| p.id),
-        "name" => matches.sort_by(|a, b| a.name.cmp(&b.name)),
-        "base" => matches.sort_by(|a, b| a.package_base.cmp(&b.package_base)),
-        "submitted" => matches.sort_by_key(|p| p.first_submitted),
-        "modified" => matches.sort_by_key(|p| p.last_modified),
+    match config.sort_by {
+        CfgSortBy::Votes => matches.sort_by(|a, b| b.num_votes.cmp(&a.num_votes)),
+        CfgSortBy::Popularity => matches.sort_by(|a, b| b.popularity.partial_cmp(&a.popularity).unwrap()),
+        CfgSortBy::Id => matches.sort_by_key(|p| p.id),
+        CfgSortBy::Name => matches.sort_by(|a, b| a.name.cmp(&b.name)),
+        CfgSortBy::Base => matches.sort_by(|a, b| a.package_base.cmp(&b.package_base)),
+        CfgSortBy::Submitted => matches.sort_by_key(|p| p.first_submitted),
+        CfgSortBy::Modified => matches.sort_by_key(|p| p.last_modified),
         _ => (),
     }
 
@@ -275,7 +277,7 @@ pub async fn search_install(config: &mut Config) -> Result<i32> {
         all_pkgs.insert(0, pkg);
     }
 
-    if config.sort_mode == "topdown" {
+    if config.sort_mode == CfgSortMode::TopDown {
         for (n, pkg) in all_pkgs.iter().enumerate() {
             match pkg {
                 AnyPkg::RepoPkg(pkg) => {
@@ -317,7 +319,7 @@ pub async fn search_install(config: &mut Config) -> Result<i32> {
     let menu = NumberMenu::new(&input);
     let mut pkgs = Vec::new();
 
-    if config.sort_mode == "topdown" {
+    if config.sort_mode == CfgSortMode::TopDown {
         for (n, pkg) in all_pkgs.iter().enumerate() {
             if menu.contains(n + 1, "") {
                 match pkg {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, CfgSearchBy, CfgSortMode, CfgMode};
+use crate::config::{Config, SortMode, Mode};
 use crate::fmt::{color_repo, print_indent};
 use crate::info;
 use crate::install::install;
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use indicatif::HumanBytes;
 use raur::{Raur, SearchBy};
 
-use crate::config::CfgSortBy;
+use crate::config::SortBy;
 
 enum AnyPkg<'a> {
     RepoPkg(alpm::Package<'a>),
@@ -30,7 +30,7 @@ pub async fn search(config: &Config) -> Result<i32> {
         .await
         .context("aur search failed")?;
 
-    if config.sort_mode == CfgSortMode::TopDown {
+    if config.sort_mode == SortMode::TopDown {
         for pkg in &repo_pkgs {
             print_alpm_pkg(config, pkg, quiet);
         }
@@ -50,7 +50,7 @@ pub async fn search(config: &Config) -> Result<i32> {
 }
 
 fn search_repos<'a>(config: &'a Config, targets: &[String]) -> Result<Vec<alpm::Package<'a>>> {
-    if targets.is_empty() || config.mode == CfgMode::Aur {
+    if targets.is_empty() || config.mode == Mode::Aur {
         return Ok(Vec::new());
     }
 
@@ -65,19 +65,19 @@ fn search_repos<'a>(config: &'a Config, targets: &[String]) -> Result<Vec<alpm::
 }
 
 async fn search_aur(config: &Config, targets: &[String]) -> Result<Vec<raur::Package>> {
-    if targets.is_empty() || config.mode == CfgMode::Repo {
+    if targets.is_empty() || config.mode == Mode::Repo {
         return Ok(Vec::new());
     }
 
     let mut matches = Vec::new();
 
     let by = match config.search_by {
-        CfgSearchBy::Name => SearchBy::Name,
-        CfgSearchBy::Maintainer => SearchBy::Maintainer,
-        CfgSearchBy::Depends => SearchBy::Depends,
-        CfgSearchBy::MakeDepends => SearchBy::MakeDepends,
-        CfgSearchBy::CheckDepends => SearchBy::CheckDepends,
-        CfgSearchBy::OptDepends => SearchBy::OptDepends,
+        SearchBy::Name => SearchBy::Name,
+        SearchBy::Maintainer => SearchBy::Maintainer,
+        SearchBy::Depends => SearchBy::Depends,
+        SearchBy::MakeDepends => SearchBy::MakeDepends,
+        SearchBy::CheckDepends => SearchBy::CheckDepends,
+        SearchBy::OptDepends => SearchBy::OptDepends,
         _ => SearchBy::NameDesc,
     };
 
@@ -117,13 +117,13 @@ async fn search_aur(config: &Config, targets: &[String]) -> Result<Vec<raur::Pac
     }
 
     match config.sort_by {
-        CfgSortBy::Votes => matches.sort_by(|a, b| b.num_votes.cmp(&a.num_votes)),
-        CfgSortBy::Popularity => matches.sort_by(|a, b| b.popularity.partial_cmp(&a.popularity).unwrap()),
-        CfgSortBy::Id => matches.sort_by_key(|p| p.id),
-        CfgSortBy::Name => matches.sort_by(|a, b| a.name.cmp(&b.name)),
-        CfgSortBy::Base => matches.sort_by(|a, b| a.package_base.cmp(&b.package_base)),
-        CfgSortBy::Submitted => matches.sort_by_key(|p| p.first_submitted),
-        CfgSortBy::Modified => matches.sort_by_key(|p| p.last_modified),
+        SortBy::Votes => matches.sort_by(|a, b| b.num_votes.cmp(&a.num_votes)),
+        SortBy::Popularity => matches.sort_by(|a, b| b.popularity.partial_cmp(&a.popularity).unwrap()),
+        SortBy::Id => matches.sort_by_key(|p| p.id),
+        SortBy::Name => matches.sort_by(|a, b| a.name.cmp(&b.name)),
+        SortBy::Base => matches.sort_by(|a, b| a.package_base.cmp(&b.package_base)),
+        SortBy::Submitted => matches.sort_by_key(|p| p.first_submitted),
+        SortBy::Modified => matches.sort_by_key(|p| p.last_modified),
         _ => (),
     }
 
@@ -277,7 +277,7 @@ pub async fn search_install(config: &mut Config) -> Result<i32> {
         all_pkgs.insert(0, pkg);
     }
 
-    if config.sort_mode == CfgSortMode::TopDown {
+    if config.sort_mode == SortMode::TopDown {
         for (n, pkg) in all_pkgs.iter().enumerate() {
             match pkg {
                 AnyPkg::RepoPkg(pkg) => {
@@ -319,7 +319,7 @@ pub async fn search_install(config: &mut Config) -> Result<i32> {
     let menu = NumberMenu::new(&input);
     let mut pkgs = Vec::new();
 
-    if config.sort_mode == CfgSortMode::TopDown {
+    if config.sort_mode == SortMode::TopDown {
         for (n, pkg) in all_pkgs.iter().enumerate() {
             if menu.contains(n + 1, "") {
                 match pkg {

--- a/src/search.rs
+++ b/src/search.rs
@@ -71,15 +71,7 @@ async fn search_aur(config: &Config, targets: &[String]) -> Result<Vec<raur::Pac
 
     let mut matches = Vec::new();
 
-    let by = match config.search_by {
-        SearchBy::Name => SearchBy::Name,
-        SearchBy::Maintainer => SearchBy::Maintainer,
-        SearchBy::Depends => SearchBy::Depends,
-        SearchBy::MakeDepends => SearchBy::MakeDepends,
-        SearchBy::CheckDepends => SearchBy::CheckDepends,
-        SearchBy::OptDepends => SearchBy::OptDepends,
-        _ => SearchBy::NameDesc,
-    };
+    let by = config.search_by;
 
     if by == SearchBy::NameDesc {
         let target = targets.iter().max_by_key(|t| t.len()).unwrap();

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{Config, CfgMode};
 use crate::exec;
 
 use std::io::Write;
@@ -24,11 +24,11 @@ pub async fn filter(config: &Config) -> Result<i32> {
 pub async fn list(config: &Config) -> Result<i32> {
     let mut args = config.pacman_args();
 
-    let mut show_aur = args.targets.is_empty() && config.mode != "repo";
+    let mut show_aur = args.targets.is_empty() && config.mode != CfgMode::Repo;
     let dbs = config.alpm.syncdbs();
 
     if args.targets.is_empty() {
-        if config.mode != "aur" {
+        if config.mode != CfgMode::Aur {
             args.targets = dbs.iter().map(|db| db.name()).collect();
         }
     };

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, CfgMode};
+use crate::config::{Config, Mode};
 use crate::exec;
 
 use std::io::Write;
@@ -24,11 +24,11 @@ pub async fn filter(config: &Config) -> Result<i32> {
 pub async fn list(config: &Config) -> Result<i32> {
     let mut args = config.pacman_args();
 
-    let mut show_aur = args.targets.is_empty() && config.mode != CfgMode::Repo;
+    let mut show_aur = args.targets.is_empty() && config.mode != Mode::Repo;
     let dbs = config.alpm.syncdbs();
 
     if args.targets.is_empty() {
-        if config.mode != CfgMode::Aur {
+        if config.mode != Mode::Aur {
             args.targets = dbs.iter().map(|db| db.name()).collect();
         }
     };

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, CfgMode, LocalRepos};
+use crate::config::{Config, Mode, LocalRepos};
 use crate::devel::{filter_devel_updates, possible_devel_updates};
 use crate::fmt::color_repo;
 use crate::repo;
@@ -111,7 +111,7 @@ async fn get_aur_only_upgrades<'a, 'b>(
     resolver: &mut Resolver<'a, 'b>,
     print: bool,
 ) -> Result<AurUpdates<'a>> {
-    if config.mode != CfgMode::Repo {
+    if config.mode != Mode::Repo {
         if print {
             let c = config.color;
             println!(
@@ -137,7 +137,7 @@ async fn get_aur_only_upgrades<'a, 'b>(
 }
 
 async fn get_devel_upgrades(config: &Config, print: bool) -> Result<Vec<String>> {
-    if config.devel && config.mode != CfgMode::Repo {
+    if config.devel && config.mode != Mode::Repo {
         let c = config.color;
         if print {
             println!(
@@ -185,7 +185,7 @@ pub async fn get_upgrades<'a, 'b>(
     let mut devel_upgrades =
         filter_devel_updates(config, resolver.cache(), &devel_upgrades).await?;
 
-    let repo_upgrades = if config.mode != CfgMode::Aur && config.combined_upgrade {
+    let repo_upgrades = if config.mode != Mode::Aur && config.combined_upgrade {
         repo_upgrades(config)?
     } else {
         Vec::new()

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, LocalRepos};
+use crate::config::{Config, CfgMode, LocalRepos};
 use crate::devel::{filter_devel_updates, possible_devel_updates};
 use crate::fmt::color_repo;
 use crate::repo;
@@ -111,7 +111,7 @@ async fn get_aur_only_upgrades<'a, 'b>(
     resolver: &mut Resolver<'a, 'b>,
     print: bool,
 ) -> Result<AurUpdates<'a>> {
-    if config.mode != "repo" {
+    if config.mode != CfgMode::Repo {
         if print {
             let c = config.color;
             println!(
@@ -137,7 +137,7 @@ async fn get_aur_only_upgrades<'a, 'b>(
 }
 
 async fn get_devel_upgrades(config: &Config, print: bool) -> Result<Vec<String>> {
-    if config.devel && config.mode != "repo" {
+    if config.devel && config.mode != CfgMode::Repo {
         let c = config.color;
         if print {
             println!(
@@ -185,7 +185,7 @@ pub async fn get_upgrades<'a, 'b>(
     let mut devel_upgrades =
         filter_devel_updates(config, resolver.cache(), &devel_upgrades).await?;
 
-    let repo_upgrades = if config.mode != "aur" && config.combined_upgrade {
+    let repo_upgrades = if config.mode != CfgMode::Aur && config.combined_upgrade {
         repo_upgrades(config)?
     } else {
         Vec::new()

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, CfgMode, NO_CONFIRM};
+use crate::config::{Config, Mode, NO_CONFIRM};
 
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -40,9 +40,9 @@ pub fn split_repo_aur_targets<'a, T: AsTarg>(
 
     for targ in targets {
         let targ = targ.as_targ();
-        if config.mode == CfgMode::Aur {
+        if config.mode == Mode::Aur {
             aur.push(targ);
-        } else if config.mode == CfgMode::Repo {
+        } else if config.mode == Mode::Repo {
             local.push(targ);
         } else if let Some(repo) = targ.repo {
             if repo == config.aur_namespace() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, NO_CONFIRM};
+use crate::config::{Config, CfgMode, NO_CONFIRM};
 
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -40,9 +40,9 @@ pub fn split_repo_aur_targets<'a, T: AsTarg>(
 
     for targ in targets {
         let targ = targ.as_targ();
-        if config.mode == "aur" {
+        if config.mode == CfgMode::Aur {
             aur.push(targ);
-        } else if config.mode == "repo" {
+        } else if config.mode == CfgMode::Repo {
             local.push(targ);
         } else if let Some(repo) = targ.repo {
             if repo == config.aur_namespace() {


### PR DESCRIPTION
This pull converts most of the string values in the `Config` struct to use enums instead and introduces a trait (`ConfigEnum`) for unified parsing/validating. 

I tried hard to change as little as possible and leave all semantics intact. There's one intended change in behavior as a result of this pull: Previously the config parsing code would accept only `all` or `no` values for some options from the config file while commandline processing allowed `all`, `yes` and `no`. This change will allow `yes` in the config also. If there's a reason to forbid setting `yes`  then I can make an adjustment, but I wasn't even sure the restriction was intentional.

So why is this approach preferable to the current one?

1. The typechecker will protect you against many issues when dealing with those values while its assistance is limited when manipulating string-based option values.
2. It unifies the processing of options and arguments making them easier to maintain and reason about.
3. Less code duplication.
4. Not really significant, but comparing enum values should be faster than strings.

**Note**: Only lightly tested at this point, although as far as I can see I didn't break anything. Most of the changes were straightforward.

Closes #326