### PR TITLE
Overhaul release CI jobs to automate changelog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Release
 on:
   push:
     tags:
-      - v*
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   build-releases:
@@ -59,6 +59,8 @@ jobs:
     needs: [build-releases]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
       - name: Read info
         id: tags
         shell: bash
@@ -70,6 +72,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: paru-aarch64
+      - name: Generate release changelog
+        run: |
+          sed -ne '/${{ steps.tags.outputs.tag }}/,/^## /{/^## /d;p}' CHANGELOG.md |
+            sed -e '1d;$d' > CHANGELOG-${{ steps.tags.outputs.tag }}.md
       - name: Create Release
         id: create_release
         uses: actions/create-release@master
@@ -79,6 +85,7 @@ jobs:
           tag_name: ${{ steps.tags.outputs.tag }}
           release_name: ${{ steps.tags.outputs.tag }}
           draft: true
+          body_path: CHANGELOG-${{ steps.tags.outputs.tag }}.md
           prerelease: false
       - name: Upload x86_64 asset
         id: upload-release-asset-x86_64


### PR DESCRIPTION
Given your recent [AUR comment](https://aur.archlinux.org/packages/paru/#comment-814472):

> The CI makes a draft release. I hate automated releases and it lets me write the changelog in before publishing.

I couldn't resist. Marking automated releases as drafts until hand checked and everything looks copacetic I can understand. Writing release notes by hand when you have a changelog file anyway I cannot.

The actual changelog is relatively simple:

```console
$ sed -ne '/v1.7.3/,/^## /{/^## /d;p}' CHANGELOG.md | sed -e '1d;$d'
```

As a post-script, allow me to note that your workflows look overly convoluted to me. I'm pretty sure we could get the same job done in a much less round-about way. The actions you are using for this are clumsy and not even supported any more (at least one of them is completely deprecated by GitHub officially). Would you be open to accepting an overhaul of the entire workflow process to simplify all the value passing / stages / artifact push & pulls / etc.?