### PR TITLE
pt_BR: Translate "section" -> "seção"

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2,6 +2,7 @@
 # Copyright (C) YEAR THE paru'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the paru package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# João Vitor S. Anjos <jvanjos@protonmail.com>, 2021
 #
 msgid ""
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,12 +8,12 @@ msgstr ""
 "Project-Id-Version: paru VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/Morganamilo/paru\n"
 "POT-Creation-Date: 2021-06-28 03:24+0000\n"
-"PO-Revision-Date: 2021-06-28 17:46-0300\n"
+"PO-Revision-Date: 2021-06-28 23:50-0300\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Last-Translator: Pedro Liberatti <ferrahwolfeh@protonmail.com>\n"
+"Last-Translator: João Vitor S. Anjos <jvanjos@protonmail.com>\n"
 "Language-Team: \n"
 "X-Generator: Poedit 3.0\n"
 
@@ -111,11 +111,11 @@ msgstr "valor para a chave '{}' não pode ser vazio"
 
 #: src/config.rs:756
 msgid "key '{}' does not belong to a section"
-msgstr "chave '{}' não pertence a secção"
+msgstr "chave '{}' não pertence a seção"
 
 #: src/config.rs:762
 msgid "unknown section '{}'"
-msgstr "secção '{}' desconhecida"
+msgstr "seção '{}' desconhecida"
 
 #: src/config.rs:769 src/config.rs:824 src/config.rs:829
 msgid "key can not be empty"
@@ -123,11 +123,11 @@ msgstr "chave não pode ter um valor vazio"
 
 #: src/config.rs:791
 msgid "error: unknown option '{}' in section [bin]"
-msgstr "erro: opção desconhecida '{}' na secção [bin]"
+msgstr "erro: opção desconhecida '{}' na seção [bin]"
 
 #: src/config.rs:891
 msgid "error: unknown option '{}' in section [options]"
-msgstr "erro: opção desconhecida '{}' na secção [options]"
+msgstr "erro: opção desconhecida '{}' na seção [options]"
 
 #: src/config.rs:896
 msgid "option '{}' does not take a value"


### PR DESCRIPTION
Although "secção" is valid, the correct brazillian translation is "seção". Also, pacman uses "seção": https://gitlab.archlinux.org/pacman/pacman/-/blob/master/src/pacman/po/pt_BR.po#L426-432

@DatCrazyDelphox What do you think?!