### PR TITLE
update paru.8 & paru.conf.5 to suppress troff warning

### DIFF
--- a/man/paru.8
+++ b/man/paru.8
@@ -1,4 +1,3 @@
-'\ t
 .TH "PARU" "8" "2020\-11\-2" "paru v1.0.2 "Paru Manual"
 .nh
 .ad l

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -1,4 +1,3 @@
-'\ t
 .TH "PARU.CONF" "5" "2020\-11\-2" "paru v1.0.2" "Paru Manual"
 .nh
 .ad l


### PR DESCRIPTION
When running `man paru > /dev/null` or `man paru.conf > /dev/null`, the system reports
```
troff: <standard input>:1: name expected (got '\ '): treated as missing
```
The culprit appears to be the first line in the paru.8 & paru.conf.5 files. This PR fixes this problem.