### PR TITLE
Fix '-r' and '-b' crashing paru

### DIFF
--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -101,10 +101,10 @@ impl Config {
             let mut chars = arg.chars();
             chars.next().unwrap();
 
-            while let Some(c) = chars.next() {
+            for c in chars {
                 let arg = Arg::Short(c);
                 if takes_value(arg) == TakesValue::Required {
-                    self.handle_arg(arg, Some(chars.as_str()), op_count, false)?;
+                    self.handle_arg(arg, value, op_count, false)?;
                     return Ok(true);
                 }
                 self.handle_arg(arg, None, op_count, false)?;

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -101,11 +101,16 @@ impl Config {
             let mut chars = arg.chars();
             chars.next().unwrap();
 
-            for c in chars {
+            while let Some(c) = chars.next() {
                 let arg = Arg::Short(c);
                 if takes_value(arg) == TakesValue::Required {
-                    self.handle_arg(arg, value, op_count, false)?;
-                    return Ok(true);
+                    if chars.as_str().is_empty() {
+                        self.handle_arg(arg, value, op_count, false)?;
+                        return Ok(true);
+                    } else {
+                        self.handle_arg(arg, Some(chars.as_str()), op_count, false)?;
+                        return Ok(false);
+                    }
                 }
                 self.handle_arg(arg, None, op_count, false)?;
             }


### PR DESCRIPTION
The short global pacman flags were not using the given value resulting in paru setting the respective paths to an empty string which caused a `error: failed to initialize alpm: root=/ dbpath=: could not find or read directory` crash.