### PR TITLE
nl_NL: Add missing whitespace in translation

### DIFF
--- a/po/nl.po
+++ b/po/nl.po
@@ -2,6 +2,7 @@
 # Copyright (C) YEAR THE paru'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the paru package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Ewout van Mansom <ewout@vanmansom.name>, 2021.
 #
 #, fuzzy
 msgid ""
@@ -9,13 +10,14 @@ msgstr ""
 "Project-Id-Version: paru VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/Morganamilo/paru\n"
 "POT-Creation-Date: 2021-06-28 03:24+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"PO-Revision-Date: 2021-08-05 19:08+0200\n"
+"Last-Translator: Ewout van Mansom <ewout@vanmansom.name>\n"
 "Language-Team: \n"
-"Language: nl\n"
+"Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
 #: src/clean.rs:31
 msgid "Do you want to remove ALL AUR packages from cache?"
@@ -173,7 +175,7 @@ msgstr "ongeldige json: {}"
 
 #: src/download.rs:83
 msgid "packages not in the AUR: "
-msgstr "pakket niet in de AUR"
+msgstr "pakket niet in de AUR: "
 
 #: src/download.rs:94
 msgid "marked out of date: "


### PR DESCRIPTION
I currently have some local-only packages installed and the dutch (nl_NL) translation for it lacks a space and colon.

![afbeelding](https://user-images.githubusercontent.com/981494/128415023-595972d4-0d78-4b1b-bc1d-ee119be96ba3.png)
