### PR TITLE
reorder default paru.conf, consistent with paru.conf.5

### DIFF
--- a/paru.conf
+++ b/paru.conf
@@ -9,19 +9,19 @@
 # GENERAL OPTIONS
 #
 [options]
-PgpFetch
-Devel
-Provides
-DevelSuffixes = -git -cvs -svn -bzr -darcs -always
-#AurOnly
 #BottomUp
-#RemoveMake
+#AurOnly
 #SudoLoop
-#UseAsk
-#CombinedUpgrade
+Devel
 #CleanAfter
-#UpgradeMenu
+Provides
+PgpFetch
+#CombinedUpgrade
 #NewsOnUpgrade
+#UseAsk
+#RemoveMake
+#UpgradeMenu
+DevelSuffixes = -git -cvs -svn -bzr -darcs -always
 
 #LocalRepo
 #Chroot
@@ -32,6 +32,6 @@ DevelSuffixes = -git -cvs -svn -bzr -darcs -always
 # Binary OPTIONS
 #
 #[bin]
+#Sudo = doas
 #FileManager = vifm
 #MFlags = --skippgpcheck
-#Sudo = doas


### PR DESCRIPTION
For the sake of my poor eyes :)

```plain
$ sort Morganamilo/paru/paru.conf | sha1sum
8a4e8ce2b08cde33bf40437f2409c34bc9500053  -
$ sort pull/Un1Gfn/paru.conf | sha1sum
8a4e8ce2b08cde33bf40437f2409c34bc9500053  -
```