### PR TITLE
Improve error message for failing makepkg command

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -230,10 +230,14 @@ pub fn makepkg_output<S: AsRef<OsStr>>(config: &Config, dir: &Path, args: &[S]) 
 
     if !ret.status.success() {
         bail!(
-            "{} {} {} --verifysource -Ccf: {}",
+            "{} {} {} {}: {}",
             tr!("failed to run:"),
             config.makepkg_bin,
             config.mflags.join(" "),
+            args.iter()
+                .map(|a| a.as_ref().to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(" "),
             String::from_utf8_lossy(&ret.stderr)
         )
     }


### PR DESCRIPTION
related to #491.

callers of `makepkg_output` never actually provide `--verifysource -Ccf`, but rather `--printsrcinfo` or `--packagelist`

Print the actual `args` instead.