### PR TITLE
[Minor] Make upgrade text bold (to match pacman)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -115,7 +115,7 @@ impl Colors {
             error: Style::new().fg(Red),
             warning: Style::new().fg(Yellow),
             bold: Style::new().bold(),
-            upgrade: Style::new().fg(Green),
+            upgrade: Style::new().fg(Green).bold(),
             base: Style::new().fg(Blue),
             action: Style::new().fg(Blue).bold(),
             sl_repo: Style::new().fg(Purple).bold(),


### PR DESCRIPTION
When running commands like `pacman -Qu`, pacman prints the upgrade text in green and bold, while paru currently only prints it in green. This very very minor commit fixes that disparity.

![image](https://user-images.githubusercontent.com/24192522/129461415-90c87087-4836-46be-b923-45025dc72048.png)
![image](https://user-images.githubusercontent.com/24192522/129461424-310370a3-55ec-4450-acd9-272e77cc0176.png)
