### PR TITLE
Added: rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Since we use nightly features, it's better to enforce this explicitly.

Signed-off-by: Lucius Hu <lebensterben@users.noreply.github.com>