### PR TITLE
Use `sh -c` to execute PreBuildCommand

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -549,7 +549,7 @@ async fn prepare_build(
     let srcinfos = download_pkgbuilds(config, &bases).await?;
 
     if let Some(ref cmd) = config.pre_build_command {
-        let args = [&"-c".to_string(), cmd];
+        let args = [&"-c", cmd.as_str()];
 
         for base in &bases.bases {
             let dir = config.fetch.clone_dir.join(base.package_base());

--- a/src/install.rs
+++ b/src/install.rs
@@ -549,15 +549,13 @@ async fn prepare_build(
     let srcinfos = download_pkgbuilds(config, &bases).await?;
 
     if let Some(ref cmd) = config.pre_build_command {
-        let mut split = cmd.split_whitespace();
-        let cmd = split.next().unwrap();
-        let args = split.collect::<Vec<_>>();
+        let args = [&"-c".to_string(), cmd];
 
         for base in &bases.bases {
             let dir = config.fetch.clone_dir.join(base.package_base());
             std::env::set_var("PKGBASE", base.package_base());
             std::env::set_var("VERSION", base.version());
-            exec::command(&cmd, &dir, &args)?;
+            exec::command("sh", &dir, &args)?;
         }
 
         std::env::remove_var("PKGBASE");


### PR DESCRIPTION
Using `sh -c` to execute the PreBuildCommand adds environment variable and `~` (home) expansion in the command, as well as basic (single-line) shell scripting support.

Closes #554 