### PR TITLE
Fix Clippy warnings, and upgrade dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block"
@@ -980,9 +980,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nix"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",
@@ -1296,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26aab6b48e2590e4a64d1ed808749ba06257882b461d01ca71baeb747074a6dd"
+checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
 dependencies = [
  "encoding_rs",
  "memchr",
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "rss"
-version = "1.10.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e70d6ae72f8a4333af8ce9dce58942020528430eb0d46ee2fcb5e8d4d16377"
+checksum = "36e19e299f301be17927a7c05b8fa1c621e3227e6c3a0da65492701642901ff7"
 dependencies = [
  "quick-xml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,9 @@ globset = "0.4.8"
 htmlescape = "0.3.1"
 indicatif = "0.16.2"
 kuchiki = "0.8.1"
-nix = "0.22.1"
+nix = "0.23.0"
 reqwest = { version = "0.11.4", features = ["gzip", "socks"] }
-rss = { version = "1.10.0", default-features = false }
+rss = { version = "2.0.0", default-features = false }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 smart-default = "0.6.0"

--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -91,10 +91,7 @@ impl Chroot {
     }
 
     pub fn build(&self, pkgbuild: &Path, chroot_flags: &[&str], flags: &[&str]) -> Result<()> {
-        let mut args = chroot_flags
-            .iter()
-            .map(OsStr::new)
-            .collect::<Vec<_>>();
+        let mut args = chroot_flags.iter().map(OsStr::new).collect::<Vec<_>>();
         args.push(OsStr::new("-r"));
         args.push(OsStr::new(self.path.as_os_str()));
 

--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -93,7 +93,7 @@ impl Chroot {
     pub fn build(&self, pkgbuild: &Path, chroot_flags: &[&str], flags: &[&str]) -> Result<()> {
         let mut args = chroot_flags
             .iter()
-            .map(|f| OsStr::new(f))
+            .map(OsStr::new)
             .collect::<Vec<_>>();
         args.push(OsStr::new("-r"));
         args.push(OsStr::new(self.path.as_os_str()));

--- a/src/download.rs
+++ b/src/download.rs
@@ -206,6 +206,7 @@ fn repo_pkgbuilds<'a>(config: &Config, pkgs: &[Targ<'a>]) -> Result<i32> {
     let cd = std::env::current_dir().context(tr!("could not get current directory"))?;
     let asp = &config.asp_bin;
 
+    #[allow(clippy::question_mark)]
     if Command::new(asp).output().is_err() {
         bail!(tr!("can not get repo packages: asp is not installed"));
     }

--- a/src/install.rs
+++ b/src/install.rs
@@ -849,7 +849,7 @@ fn review<'a>(config: &Config, actions: &Actions<'a>) -> Result<i32> {
                                             "{} {} {}",
                                             tr!("failed to run:"),
                                             config.bat_bin,
-                                            file.path().display().to_string()
+                                            file.path().display()
                                         )
                                     })?;
                                 let _ = stdin.write_all(&output.stdout);


### PR DESCRIPTION
There were no issues caused by upgrading and the test suite passes.

### Summary
* Clippy warnings fixed
* nix, rss upgraded (0.22.1 to 0.23.0 and 1.10.0 to 2.0.0, respectively)