### PR TITLE
allow more options to be configured in paru.conf and command line arguments

### DIFF
--- a/completions/bash
+++ b/completions/bash
@@ -70,7 +70,7 @@ _paru() {
            noconfirm noprogressbar noscriptlet quiet root verbose
 
            repo aur aururl clonedir makepkg mflags pacman git gitflags sudo sudoflags
-           asp gpg gpgflags fm fmflags completioninterval sortby searchby limit upgrademenu
+           asp gpg gpgflags fm fmflags pager completioninterval sortby searchby limit upgrademenu
            removemake noremovemake cleanafter nocleanafter rebuild rebuildall norebuild
            rebuildtree redownload noredownload redownloadall pgpfetch nopgpfetch useask
            nouseask savechanges nosavechanges combinedupgrade nocombinedupgrade

--- a/completions/fish
+++ b/completions/fish
@@ -193,6 +193,7 @@ complete -c $progname -n "not $noopt" -l git -d 'Git command to use' -f
 complete -c $progname -n "not $noopt" -l asp -d 'Asp command to use' -f
 complete -c $progname -n "not $noopt" -l gpg -d 'Gpg command to use' -f
 complete -c $progname -n "not $noopt" -l fm -d 'File manager to use' -f
+complete -c $progname -n "not $noopt" -l pager -d 'Pager command to use' -f
 complete -c $progname -n "not $noopt" -l completioninterval -d 'Refresh interval for completion cache' -f
 complete -c $progname -n "not $noopt" -l sortby -d 'Sort AUR results by a specific field during search' -xa "{votes,popularity,id,baseid,name,base,submitted,modified}"
 complete -c $progname -n "not $noopt" -l searchby -d 'Search for AUR packages by querying the specified field' -xa "{name,name-desc,maintainer,depends,checkdepends,makedepends,optdepends}"

--- a/completions/zsh
+++ b/completions/zsh
@@ -57,6 +57,7 @@ _pacman_opts_common=(
 	'--gpg[gpg command to use]:gpg:_files'
 	'--fm[file manager to use]:fm:_files'
 	'--asp[asp command to use]:asp:_files'
+	'--pager[pager command to use]:pager:_files'
 
 	'--sortby[Sort AUR results by a specific field during search]:sortby options:(votes popularity id baseid name base submitted modified)'
 	'--upgrademenu[Show a detailed list of updates with the option to skip any]'

--- a/paru.conf
+++ b/paru.conf
@@ -14,15 +14,27 @@ Devel
 Provides
 DevelSuffixes = -git -cvs -svn -bzr -darcs -always -hg
 #AurOnly
+#RepoOnly
+#AurUrl
+#BuildDir
 #BottomUp
+#SearchBy
+#SortBy
+#Limit
+#NoWarn
 #RemoveMake
 #SudoLoop
 #UseAsk
+#SkipReview
+#NoCheck
+#Redownload
 #SaveChanges
 #CombinedUpgrade
 #CleanAfter
 #UpgradeMenu
 #NewsOnUpgrade
+#Comments
+#MakepkgConf = /etc/paru/makepkg.conf
 
 #LocalRepo
 #Chroot
@@ -33,6 +45,19 @@ DevelSuffixes = -git -cvs -svn -bzr -darcs -always -hg
 # Binary OPTIONS
 #
 #[bin]
+#Makepkg = /usr/bin/makepkg
+#Pacman = /usr/bin/pacman
+#Git = /usr/bin/git
+#Gitflags = -P
+#Asp = /usr/bin/asp
+#Gpg = /usr/bin/gpg
+#GpgFlags = -v
+#Pager = more
+#Bat = /usr/bin/bat
+#BatFlags = --theme Dracula
 #FileManager = vifm
+#FileManagerFlags = --onchoose nano
 #MFlags = --skippgpcheck
 #Sudo = doas
+#SudoFlags
+#PreBuildCommand

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -178,6 +178,7 @@ impl Config {
             Arg::Long("asp") => self.asp_bin = value?.to_string(),
             Arg::Long("bat") => self.bat_bin = value?.to_string(),
             Arg::Long("fm") => self.fm = Some(value?.to_string()),
+            Arg::Long("pager") => self.pager_cmd = Some(value?.to_string()),
             Arg::Long("config") => self.pacman_conf = Some(value?.to_string()),
 
             Arg::Long("builddir") | Arg::Long("clonedir") => self.build_dir = value?.into(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -849,6 +849,7 @@ impl Config {
             "UseAsk" => self.use_ask = true,
             "SaveChanges" => self.save_changes = true,
             "NewsOnUpgrade" => self.news_on_upgrade = true,
+            "Comments" => self.comments = true,
             "InstallDebug" => self.install_debug = true,
             "Redownload" => self.redownload = YesNoAll::All.default_or(key, value)?,
             "Rebuild" => self.rebuild = YesNoAll::All.default_or(key, value)?,
@@ -900,6 +901,7 @@ impl Config {
             "Limit" => self.limit = value?.parse()?,
             "CompletionInterval" => self.completion_interval = value?.parse()?,
             "PacmanConf" => self.pacman_conf = Some(value?),
+            "MakepkgConf" => self.makepkg_conf = Some(value?),
             "DevelSuffixes" => {
                 self.devel_suffixes
                     .extend(value?.split_whitespace().map(|s| s.to_string()));


### PR DESCRIPTION
This pull request allows for more internal configuration options (namely `config.comments`, `config.makepkg_conf`, and `config.pager`) to be changed in the configuration file and passed as command line arguments. I updated the shell completions and the defualt `paru.conf` to reflect the changes as well.

I only added cli arguments that I found to be a configuration option in `src/config.rs` but not in `src/command_line.rs`. I did something similar with the configuration file options by adding configuration options that were avalible but not present in the `parse_*()` functions of `src/config.rs`. I checked a few times to make sure I got them all, ignoring some options I believed shouldn't be included

...but I wouldn't be surprised if I missed some