### PR TITLE
Install "base" package when creating chroot

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -210,7 +210,7 @@ pub async fn build_pkgbuild(config: &mut Config) -> Result<i32> {
 
     if config.chroot {
         if !chroot.exists() {
-            chroot.create(config, &["base-devel"])?;
+            chroot.create(config, &["base", "base-devel"])?;
         } else {
             chroot.update()?;
         }
@@ -1287,7 +1287,7 @@ async fn build_install_pkgbuilds<'a>(config: &mut Config, bi: &mut BuildInfo) ->
 
     if config.chroot {
         if !chroot.exists() {
-            chroot.create(config, &["base-devel"])?;
+            chroot.create(config, &["base", "base-devel"])?;
         } else {
             chroot.update()?;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -453,7 +453,7 @@ fn handle_chroot(config: &Config) -> Result<i32> {
     };
 
     if !chroot.exists() {
-        chroot.create(config, &["base-devel"])?;
+        chroot.create(config, &["base", "base-devel"])?;
     }
 
     if config.update {


### PR DESCRIPTION
Fixes builds that assume dependencies of base will be installed (which is reasonable since any real Arch system will have it installed), such as those using nvm.