### PR TITLE
Updated paru.conf 's default #bottomup

### DIFF
--- a/paru.conf
+++ b/paru.conf
@@ -14,7 +14,7 @@ Devel
 Provides
 DevelSuffixes = -git -cvs -svn -bzr -darcs -always -hg
 #AurOnly
-#BottomUp
+BottomUp
 #RemoveMake
 #SudoLoop
 #UseAsk


### PR DESCRIPTION
It is the best  to show the top results on down the prompt ,
Because everyone will probably edit the .conf file after installing 
Or continue using " yay " if they are lazy.