### PR TITLE
Fix alignment for comments flag

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -621,7 +621,7 @@ msgstr "    -p --print            Imprimir pkgbuild en stdout"
 
 #: src/help.rs:91
 msgid "    -c --comments         Print AUR comments for pkgbuild"
-msgstr "   -c --comments         Mostrar comentarios de AUR para pkgbuild"
+msgstr "    -c --comments         Mostrar comentarios de AUR para pkgbuild"
 
 #: src/help.rs:93
 msgid "upgrade specific options:"


### PR DESCRIPTION
Adds a missing space when showing available flags in spanish. Sorry I didn't see it sooner.

![image](https://user-images.githubusercontent.com/29999427/148679366-f3cb0435-0900-47ca-a3d2-9fef20c1021c.png)
