### PR TITLE
Implement flag to download AUR packages via SSH

### DIFF
--- a/man/paru.8
+++ b/man/paru.8
@@ -195,6 +195,10 @@ Prints the PKGBUILD to the terminal instead of downloading it.
 .B \-c, \-\-comments
 Print the AUR comments from the PKGBUILD's AUR page.
 
+.TP
+.B \-s, \-\-ssh
+Clone the AUR package using SSH (e.g.: a read-write remote).
+
 .SH REPOCTL OPTIONS (APPLY TO \-L AND \-\-REPOCTL)
 .TP
 .B \-l, \-\-list

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -203,7 +203,11 @@ impl Config {
             Arg::Long("searchby") => self.search_by = ConfigEnum::from_str(argkey, value?)?,
             Arg::Long("limit") => self.limit = value?.parse()?,
             Arg::Long("news") | Arg::Short('w') => self.news += 1,
-            Arg::Long("stats") | Arg::Short('s') => self.stats = true,
+            Arg::Long("stats") => self.stats = true,
+            Arg::Short('s') => {
+                self.stats = true;
+                self.ssh = true;
+            }
             Arg::Long("order") | Arg::Short('o') => self.order = true,
             Arg::Long("removemake") => {
                 self.remove_make = YesNoAsk::Yes.default_or(argkey, value.ok())?
@@ -269,6 +273,7 @@ impl Config {
             Arg::Long("newsonupgrade") => self.news_on_upgrade = true,
             Arg::Long("nonewsonupgrade") => self.news_on_upgrade = false,
             Arg::Long("comments") => self.comments = true,
+            Arg::Long("ssh") => self.ssh = true,
             // ops
             Arg::Long("database") | Arg::Short('D') => set_op(Op::Database),
             Arg::Long("files") | Arg::Short('F') => set_op(Op::Files),

--- a/src/config.rs
+++ b/src/config.rs
@@ -390,6 +390,7 @@ pub struct Config {
     pub print: bool,
     pub news_on_upgrade: bool,
     pub comments: bool,
+    pub ssh: bool,
     pub sign: Sign,
     pub sign_db: Sign,
 
@@ -614,12 +615,22 @@ impl Config {
             self.raur = crate::mock::Mock::new()?;
         }
 
+        let aur_url = if self.ssh {
+            self.aur_url
+                .to_string()
+                .replacen("https://", "ssh://aur@", 1)
+                .parse()
+                .expect("change AUR URL schema from HTTPS to SSH")
+        } else {
+            self.aur_url.clone()
+        };
+
         self.fetch = aur_fetch::Handle {
             git: self.git_bin.clone().into(),
             git_flags: self.git_flags.clone(),
             clone_dir: self.build_dir.clone(),
             diff_dir: self.cache_dir.join("diff"),
-            aur_url: self.aur_url.clone(),
+            aur_url,
         };
 
         self.need_root = self.need_root();

--- a/src/help.rs
+++ b/src/help.rs
@@ -89,6 +89,7 @@ pub fn help() {
     printtr!("getpkgbuild specific options:");
     printtr!("    -p --print            Print pkgbuild to stdout");
     printtr!("    -c --comments         Print AUR comments for pkgbuild");
+    printtr!("    -s --ssh              Clone package using SSH");
     println!();
     printtr!("upgrade specific options:");
     printtr!("    -i --install          Install package as well as building");


### PR DESCRIPTION
Implement a new `-e` or `--editable` flag to download AUR packages using
SSH.

Fixes #399