### PR TITLE
Fix typos in paru.conf man page

### DIFF
--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -312,14 +312,14 @@ Command to use for paging
 
 .TP
 .B PreBuildCommand = Command
-Command will be executed for each package before it is build.
+Command will be executed for each package before it is built.
 
 The command will be run via 'sh -c' and the command's current directory will be
 set to the directory containing the package's PKGBUILD. If a package is already
 built then the build will be skipped but this command will still be run for
 that package.
 
-the variables PKGBASE and VERSION will be set for the command to use.
+The variables PKGBASE and VERSION will be set for the command to use.
 
 .SH ENV
 Set environment variables.


### PR DESCRIPTION
Fix two small typos in the `paru.conf` man page.