### PR TITLE
Improve default settings for paru.conf

### DIFF
--- a/paru.conf
+++ b/paru.conf
@@ -23,6 +23,7 @@ DevelSuffixes = -git -cvs -svn -bzr -darcs -always -hg
 #CleanAfter
 #UpgradeMenu
 #NewsOnUpgrade
+#SkipReview=always
 
 #LocalRepo
 #Chroot


### PR DESCRIPTION
It might be a good idea to add a disabled-by-default option for skipping review process into ``paru.conf``.
Can you consider also changing the default option and enable ``BottomUp`` by default?
Displaying the most relevant results at the bottom will improve initial UX.