### PR TITLE
fix: typo in fish completion

### DIFF
--- a/completions/fish
+++ b/completions/fish
@@ -5,7 +5,7 @@
 set -l progname paru
 
 # paru constants
-set -l noopt 'not __fish_contains_opt -s -s G -s V -s P -s S -s D -s Q -s R -s U -s T -s F database query sync remove upgrade deptest files version'
+set -l noopt 'not __fish_contains_opt -s G -s V -s P -s S -s D -s Q -s R -s U -s T -s F database query sync remove upgrade deptest files version'
 set -l listall "(paru -Pc | string replace ' ' \t)"
 set -l listpacman "(__fish_print_packages)"
 set -l paruspecific '__fish_contains_opt -s'


### PR DESCRIPTION
fish can't complete `paru --s` to `paru --sync` caused by this

* I didn't test all cases