### PR TITLE
Fix typo in import GPG keys string

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -554,8 +554,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} està actualitzat -- s'està ometent la instal·lació"
 
 #: src/keys.rs:47
-msgid "keys need to be imported:)"
-msgstr "cal importar les claus:)"
+msgid "keys need to be imported:"
+msgstr "cal importar les claus:"
 
 #: src/keys.rs:52
 msgid "     {key} wanted by: {base}"

--- a/po/de.po
+++ b/po/de.po
@@ -550,8 +550,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} ist aktuell — Überspringe Installation"
 
 #: src/keys.rs:47
-msgid "keys need to be imported:)"
-msgstr "Schlüssel müssen importiert werden:)"
+msgid "keys need to be imported:"
+msgstr "Schlüssel müssen importiert werden:"
 
 #: src/keys.rs:52
 msgid "     {key} wanted by: {base}"

--- a/po/es.po
+++ b/po/es.po
@@ -944,8 +944,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} está actualizado -- saltando instalación"
 
 #: src/keys.rs:48
-msgid "keys need to be imported:)"
-msgstr "se necesitan importar claves :)"
+msgid "keys need to be imported:"
+msgstr "se necesitan importar claves :"
 
 #: src/keys.rs:53
 msgid "     {key} wanted by: {base}"

--- a/po/fi.po
+++ b/po/fi.po
@@ -538,8 +538,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} on ajantasalla -- ohitetaan asennus"
 
 #: src/keys.rs:47
-msgid "keys need to be imported:)"
-msgstr "avaimet on asennettava:)"
+msgid "keys need to be imported:"
+msgstr "avaimet on asennettava:"
 
 #: src/keys.rs:52
 msgid "     {key} wanted by: {base}"

--- a/po/fr.po
+++ b/po/fr.po
@@ -932,8 +932,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} est à jour -- installation ignorée"
 
 #: src/keys.rs:48
-msgid "keys need to be imported:)"
-msgstr "les clés doivent être importés :)"
+msgid "keys need to be imported:"
+msgstr "les clés doivent être importés :"
 
 #: src/keys.rs:53
 msgid "     {key} wanted by: {base}"

--- a/po/hi.po
+++ b/po/hi.po
@@ -551,8 +551,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} अप टू डेट है -- लंघन इंस्टाल"
 
 #: src/keys.rs:47
-msgid "keys need to be imported:)"
-msgstr "keys को आयात करने की आवश्यकता है:)"
+msgid "keys need to be imported:"
+msgstr "keys को आयात करने की आवश्यकता है:"
 
 #: src/keys.rs:52
 msgid "     {key} wanted by: {base}"

--- a/po/hr.po
+++ b/po/hr.po
@@ -850,8 +850,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} je ažuriran -- preskakanje instalacije"
 
 #: src/keys.rs:48
-msgid "keys need to be imported:)"
-msgstr "klučevi moraju biti uvezeni:)"
+msgid "keys need to be imported:"
+msgstr "klučevi moraju biti uvezeni:"
 
 #: src/keys.rs:53
 msgid "     {key} wanted by: {base}"

--- a/po/it.po
+++ b/po/it.po
@@ -548,8 +548,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} è aggiornato -- saltando l'installazione"
 
 #: src/keys.rs:47
-msgid "keys need to be imported:)"
-msgstr "le chiavi devono essere importate:)"
+msgid "keys need to be imported:"
+msgstr "le chiavi devono essere importate:"
 
 #: src/keys.rs:52
 msgid "     {key} wanted by: {base}"

--- a/po/ja.po
+++ b/po/ja.po
@@ -864,8 +864,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} は最新です -- インストールをスキップ"
 
 #: src/keys.rs:48
-msgid "keys need to be imported:)"
-msgstr "鍵をインポートする必要があります:)"
+msgid "keys need to be imported:"
+msgstr "鍵をインポートする必要があります:"
 
 #: src/keys.rs:53
 msgid "     {key} wanted by: {base}"

--- a/po/ko.po
+++ b/po/ko.po
@@ -905,8 +905,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} 현재 최신버전입 -- 설치 건너뛰는 중"
 
 #: src/keys.rs:48
-msgid "keys need to be imported:)"
-msgstr "키를 불러와야 합니다:)"
+msgid "keys need to be imported:"
+msgstr "키를 불러와야 합니다:"
 
 #: src/keys.rs:53
 msgid "     {key} wanted by: {base}"

--- a/po/nl.po
+++ b/po/nl.po
@@ -540,8 +540,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} is actueel -- installatie overslaan"
 
 #: src/keys.rs:47
-msgid "keys need to be imported:)"
-msgstr "sleutels moeten geïmporteerd worden:)"
+msgid "keys need to be imported:"
+msgstr "sleutels moeten geïmporteerd worden:"
 
 #: src/keys.rs:52
 msgid "     {key} wanted by: {base}"

--- a/po/paru.pot
+++ b/po/paru.pot
@@ -860,7 +860,7 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr ""
 
 #: src/keys.rs:48
-msgid "keys need to be imported:)"
+msgid "keys need to be imported:"
 msgstr ""
 
 #: src/keys.rs:53

--- a/po/pt.po
+++ b/po/pt.po
@@ -940,8 +940,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} está atualizado -- a ignorar instalação"
 
 #: src/keys.rs:48
-msgid "keys need to be imported:)"
-msgstr "chaves precisam ser importadas:)"
+msgid "keys need to be imported:"
+msgstr "chaves precisam ser importadas:"
 
 #: src/keys.rs:53
 msgid "     {key} wanted by: {base}"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -988,8 +988,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} está atualizado -- pulando instalação"
 
 #: src/keys.rs:48
-msgid "keys need to be imported:)"
-msgstr "chaves precisam ser importadas:)"
+msgid "keys need to be imported:"
+msgstr "chaves precisam ser importadas:"
 
 #: src/keys.rs:53
 msgid "     {key} wanted by: {base}"

--- a/po/ro.po
+++ b/po/ro.po
@@ -549,8 +549,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} este actualizat la ultima versiune -- se sare peste instalare"
 
 #: src/keys.rs:47
-msgid "keys need to be imported:)"
-msgstr "cheile trebuie importate:)"
+msgid "keys need to be imported:"
+msgstr "cheile trebuie importate:"
 
 #: src/keys.rs:52
 msgid "     {key} wanted by: {base}"

--- a/po/ru.po
+++ b/po/ru.po
@@ -895,8 +895,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} уже свежих версий --- пропускаем установку"
 
 #: src/keys.rs:48
-msgid "keys need to be imported:)"
-msgstr "нужно импортировать ключи:)"
+msgid "keys need to be imported:"
+msgstr "нужно импортировать ключи:"
 
 #: src/keys.rs:53
 msgid "     {key} wanted by: {base}"

--- a/po/sv.po
+++ b/po/sv.po
@@ -538,8 +538,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} är aktuell -- hoppar över installation"
 
 #: src/keys.rs:47
-msgid "keys need to be imported:)"
-msgstr "nycklar behövs importeras:)"
+msgid "keys need to be imported:"
+msgstr "nycklar behövs importeras:"
 
 #: src/keys.rs:52
 msgid "     {key} wanted by: {base}"

--- a/po/tr.po
+++ b/po/tr.po
@@ -550,8 +550,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} güncel -- yükleme es geçiliyor"
 
 #: src/keys.rs:47
-msgid "keys need to be imported:)"
-msgstr "anahtar içe aktarılmalıdır:)"
+msgid "keys need to be imported:"
+msgstr "anahtar içe aktarılmalıdır:"
 
 #: src/keys.rs:52
 msgid "     {key} wanted by: {base}"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -893,8 +893,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} 已是最新 -- 跳过安装"
 
 #: src/keys.rs:48
-msgid "keys need to be imported:)"
-msgstr "需要导入公钥:)"
+msgid "keys need to be imported:"
+msgstr "需要导入公钥:"
 
 #: src/keys.rs:53
 msgid "     {key} wanted by: {base}"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -867,8 +867,8 @@ msgid "{}-{} is up to date -- skipping install"
 msgstr "{}-{} 已為最新 -- 略過安裝"
 
 #: src/keys.rs:48
-msgid "keys need to be imported:)"
-msgstr "必須匯入金鑰:)"
+msgid "keys need to be imported:"
+msgstr "必須匯入金鑰:"
 
 #: src/keys.rs:53
 msgid "     {key} wanted by: {base}"

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -45,7 +45,7 @@ pub fn check_pgp_keys(
         println!(
             "{} {}",
             c.action.paint("::"),
-            c.bold.paint(tr!("keys need to be imported:)"))
+            c.bold.paint(tr!("keys need to be imported:"))
         );
         for (key, base) in &import {
             let base = base.iter().map(|s| s.to_string()).collect::<Vec<_>>();


### PR DESCRIPTION
This PR removes an extra bracket added in commit [5b1ff38b0357844193ca7accd2fcf6b13fb4802f](https://github.com/Morganamilo/paru/commit/5b1ff38b0357844193ca7accd2fcf6b13fb4802f#diff-dd5ba1bca5a2e982ec6f7d24bac5d1b5588e12912d838585931ce9547411cccbR47).

PS: I used `sed` to fix the strings, let me know if I have to use `xtr` instead for the translation files.