### PR TITLE
fix: `-L -C` detection and incorrect inherited from yay

### DIFF
--- a/completions/fish
+++ b/completions/fish
@@ -5,10 +5,9 @@
 set -l progname paru
 
 # paru constants
-set -l noopt 'not __fish_contains_opt -s G -s V -s P -s S -s D -s Q -s R -s U -s T -s F -s L -s C database query sync remove upgrade deptest files version repoctl chrootctl'
+set -l noopt 'not __fish_contains_opt -s G -s V -s P -s S -s D -s Q -s R -s U -s T -s F -s L -s C -s c database query sync remove upgrade deptest files version repoctl chrootctl gendb'
 set -l listall "(paru -Pc | string replace ' ' \t)"
 set -l listpacman "(__fish_print_packages)"
-set -l paruspecific '__fish_contains_opt -s'
 set -l show '__fish_contains_opt -s P show'
 set -l getpkgbuild '__fish_contains_opt -s G getpkgbuild'
 set -l repoctl '__fish_contains_opt -s L repoctl'
@@ -161,8 +160,8 @@ complete -c $progname -s C -f -l chrootctl -n "$noopt" -d 'Interactive shell to 
 
 
 # paru options
-complete -c $progname -n "$paruspecific" -s c -l clean -d 'Remove unneeded dependencies' -f
-complete -c $progname -n "$paruspecific" -l gendb -d 'Generate development package DB' -f
+complete -c $progname -s c -l clean -n "$noopt" -d 'Remove unneeded dependencies' -f
+complete -c $progname -l gendb -n "$noopt" -d 'Generate development package DB' -f
 
 # Show options
 complete -c $progname -n "$show" -s w -l news -d 'Print arch news' -f

--- a/completions/fish
+++ b/completions/fish
@@ -5,7 +5,7 @@
 set -l progname paru
 
 # paru constants
-set -l noopt 'not __fish_contains_opt -s G -s V -s P -s S -s D -s Q -s R -s U -s T -s F database query sync remove upgrade deptest files version'
+set -l noopt 'not __fish_contains_opt -s G -s V -s P -s S -s D -s Q -s R -s U -s T -s F -s L database query sync remove upgrade deptest files version repoctl'
 set -l listall "(paru -Pc | string replace ' ' \t)"
 set -l listpacman "(__fish_print_packages)"
 set -l paruspecific '__fish_contains_opt -s'

--- a/completions/fish
+++ b/completions/fish
@@ -5,7 +5,7 @@
 set -l progname paru
 
 # paru constants
-set -l noopt 'not __fish_contains_opt -s G -s V -s P -s S -s D -s Q -s R -s U -s T -s F -s L database query sync remove upgrade deptest files version repoctl'
+set -l noopt 'not __fish_contains_opt -s G -s V -s P -s S -s D -s Q -s R -s U -s T -s F -s L -s C database query sync remove upgrade deptest files version repoctl chrootctl'
 set -l listall "(paru -Pc | string replace ' ' \t)"
 set -l listpacman "(__fish_print_packages)"
 set -l paruspecific '__fish_contains_opt -s'

--- a/completions/fish
+++ b/completions/fish
@@ -5,7 +5,7 @@
 set -l progname paru
 
 # paru constants
-set -l noopt 'not __fish_contains_opt -s G -s V -s P -s S -s D -s Q -s R -s U -s T -s F -s L -s C -s c database query sync remove upgrade deptest files version repoctl chrootctl gendb'
+set -l noopt 'not __fish_contains_opt -s G -s V -s P -s S -s D -s Q -s R -s U -s T -s F -s L -s C database query sync remove upgrade deptest files version repoctl chrootctl gendb'
 set -l listall "(paru -Pc | string replace ' ' \t)"
 set -l listpacman "(__fish_print_packages)"
 set -l show '__fish_contains_opt -s P show'


### PR DESCRIPTION
- fix: lost `-L --repoctl` detection in fish comp
- fix: also for `-C --chrootctl
- fix: incorrect completion inherited from yay