### PR TITLE
Remove the outdated description of AurUrl

### DIFF
--- a/man/paru.8
+++ b/man/paru.8
@@ -249,8 +249,7 @@ Note that dependency resolution will still include repository packages.
 
 .TP
 .B \-\-aururl
-Set an alternative AUR URL. This is mostly useful for users in China who wish
-to use https://aur.tuna.tsinghua.edu.cn/.
+Set an alternative AUR URL.
 
 .TP
 .B \-\-clonedir <dir>

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -158,8 +158,7 @@ it is up to the user what upgrades they skip.
 
 .TP
 .B AurUrl = URL
-Set an alternative AUR URL. This is mostly useful for users in China who wish
-to use https://aur.tuna.tsinghua.edu.cn/.
+Set an alternative AUR URL.
 
 .TP
 .B CloneDir = /path/to/dir


### PR DESCRIPTION
Proposed in https://github.com/tuna/issues/issues/1424 and [announced officially](https://mirrors.tuna.tsinghua.edu.cn/news/remove-aur/), the AUR mirror at TUNA has retired for months. The URL clearly does not work any longer, so better removal than confusions for now.