### PR TITLE
Fix man page typos

### DIFF
--- a/man/paru.8
+++ b/man/paru.8
@@ -204,6 +204,7 @@ Clone the AUR package using SSH (e.g.: a read-write remote).
 .B \-l, \-\-list
 List packages in local repos
 
+.TP
 .B \-c, \-\-clean
 Remove packages that are not currently installed from repos.
 
@@ -381,6 +382,7 @@ this can lead to partial upgrades. This feature is intended to easily skip AUR
 updates on the fly that may be broken or have a long compile time. Ultimately
 it is up to the user what upgrades they skip.
 
+.TP
 .B \-\-noupgrademenu
 Do not show the upgrade menu.
 


### PR DESCRIPTION
Missing `.TP`'s were causing some options to be incorrectly indented.