### PR TITLE
Don't update package DB unless `-u` is specified

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -754,7 +754,12 @@ impl Installer {
             if !self.chroot.exists() {
                 self.chroot.create(config, &["base-devel"])?;
             } else {
-                self.chroot.update()?;
+                if config.refresh {
+                    self.chroot.run(&["pacman", "-Sy", "--noconfirm"])?;
+                }
+                if config.sysupgrade {
+                    self.chroot.run(&["pacman", "-Su", "--noconfirm"])?;
+                }
             }
         }
 


### PR DESCRIPTION
When running `paru -U` repeatedly on the same file, paru will update the
system package DB each time. This is slow and impractical when doing
repeated builds of the same package (e.g.: when using `paru` as an
improved `makepkg -fc`).

This change avoids updating the system package DB unless `-u` has been
specified.

Fixes: https://github.com/Morganamilo/paru/issues/782