### PR TITLE
Move devel.json to $XDG_STATE_HOME

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -541,7 +541,7 @@ impl Config {
         let config_path = config.join("paru.conf");
 
         // Check if devel.json is present in cache dir & move to state dir if true
-        if old_devel_path.exists() {
+        if !devel_path.exists() && old_devel_path.exists() {
             if !state.exists() {
                 std::fs::create_dir(&state)?;
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -536,18 +536,19 @@ impl Config {
         let state = state.join("paru");
 
         let build_dir = cache.join("clone");
+        let old_devel_path = cache.join("devel.json");
+        let devel_path = state.join("devel.json");
         let config_path = config.join("paru.conf");
 
         // Check if devel.json is present in cache dir & move to state dir if true
-        if cache.join("devel.json").exists() {
+        if old_devel_path.exists() {
             if !state.exists() {
                 std::fs::create_dir(&state)?;
             }
-            std::fs::copy(cache.join("devel.json"), state.join("devel.json"))?;
-            std::fs::remove_file(cache.join("devel.json"))?;
+            std::fs::copy(&old_devel_path, &devel_path)?;
+            std::fs::remove_file(&old_devel_path)?;
         }
 
-        let devel_path = state.join("devel.json");
         let cache_dir = cache;
 
         let color = Colors::from("never");

--- a/src/config.rs
+++ b/src/config.rs
@@ -531,10 +531,23 @@ impl Config {
         let config =
             dirs::config_dir().ok_or_else(|| anyhow!(tr!("failed to find config directory")))?;
         let config = config.join("paru");
+        let state =
+            dirs::state_dir().ok_or_else(|| anyhow!(tr!("failed to find state directory")))?;
+        let state = state.join("paru");
 
         let build_dir = cache.join("clone");
         let config_path = config.join("paru.conf");
-        let devel_path = cache.join("devel.json");
+
+        // Check if devel.json is present in cache dir & move to state dir if true
+        if cache.join("devel.json").exists() {
+            if !state.exists() {
+                std::fs::create_dir(&state)?;
+            }
+            std::fs::copy(cache.join("devel.json"), state.join("devel.json"))?;
+            std::fs::remove_file(cache.join("devel.json"))?;
+        }
+
+        let devel_path = state.join("devel.json");
         let cache_dir = cache;
 
         let color = Colors::from("never");


### PR DESCRIPTION
This addresses #231 by setting `devel_path` to `$XDG_STATE_HOME` and moving
existing `devel.json` files from the cache dir to the new location.

This is basically just an updated version of [this pr](https://github.com/Morganamilo/paru/pull/508) which didn't use
`$XDG_STATE_HOME` since it was unsupported in dirs at the time.