### PR TITLE
Prevents crashing due to repeated symlinks

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -1041,10 +1041,12 @@ impl Installer {
         }
 
         if !config.skip_review {
-            let pkgs = actions
+            let mut pkgs = actions
                 .iter_aur_pkgs()
                 .map(|b| b.pkg.package_base.as_str())
                 .collect::<Vec<_>>();
+            pkgs.sort_unstable();
+            pkgs.dedup();
             review(config, &config.fetch, &pkgs)?;
         }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -1041,12 +1041,15 @@ impl Installer {
         }
 
         if !config.skip_review {
-            let mut pkgs = actions
-                .iter_aur_pkgs()
-                .map(|b| b.pkg.package_base.as_str())
+            let pkgs = actions
+                .build
+                .iter()
+                .filter(|b| b.build())
+                .filter_map(|b| match b {
+                    Base::Aur(pkg) => Some(pkg.package_base()),
+                    Base::Custom(_) => None,
+                })
                 .collect::<Vec<_>>();
-            pkgs.sort_unstable();
-            pkgs.dedup();
             review(config, &config.fetch, &pkgs)?;
         }
 


### PR DESCRIPTION
Fixes #832.

I'm not sure whether sorting is actually necessary here or whether `actions` is already sorted. If it _is_ already sorted, please let me know so I can remove that line (or remove it yourself if you don't want to wait for me—I'm leaving "Allow edits by maintainers" enabled).