### PR TITLE
Don't skip review if --review was explicitly set, even if --noconfirm is set

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -1572,7 +1572,7 @@ fn print_dir(
 }
 
 fn review(config: &Config, fetch: &aur_fetch::Fetch, pkgs: &[&str]) -> Result<()> {
-    if !config.no_confirm {
+    if !config.no_confirm || !config.skip_review {
         if let Some(ref fm) = config.fm {
             let _view = file_manager(config, fetch, fm, pkgs)?;
 


### PR DESCRIPTION
I thought this would make it so `paru -Syu --noconfirm --review` would skip confirmation at pacman updates but still stop for review of AUR packages.

This change doesn't do that though. It still skips over the review process.

Any suggestions on how to get it to work as expected?