### PR TITLE
Use `terminal_size` crate instead of unmaintained `term_size`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "terminal_size",
+ "terminal_size 0.1.17",
  "winapi",
 ]
 
@@ -480,6 +480,27 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -887,6 +908,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +979,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "winapi",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "locale_config"
@@ -1295,7 +1328,7 @@ dependencies = [
  "smart-default",
  "srcinfo",
  "tempfile",
- "term_size",
+ "terminal_size 0.2.1",
  "tokio",
  "tr",
  "unicode-width",
@@ -1655,6 +1688,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.35.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c825b8aa8010eb9ee99b75f05e10180b9278d161583034d7574c9d617aeada"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,16 +1967,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,6 +1983,16 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
+dependencies = [
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.82"
 smart-default = "0.6.0"
 tempfile = "3.3.0"
-term_size = "0.3.2"
+terminal_size = "0.2.1"
 tokio = { version = "1.19.2", features = ["process", "macros", "rt-multi-thread"] }
 url = "2.2.2"
 env_logger = "0.9.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -569,7 +569,7 @@ impl Config {
         let cache_dir = cache;
 
         let color = Colors::from("never");
-        let cols = term_size::dimensions_stdout().map(|v| v.0);
+        let cols = terminal_size::terminal_size().map(|(w, _)| w.0 as usize);
 
         let mut config = Self {
             cols,

--- a/src/info.rs
+++ b/src/info.rs
@@ -14,7 +14,7 @@ use anyhow::Error;
 use aur_depends::Repo;
 use raur::ArcPackage as Package;
 use srcinfo::{ArchVec, Srcinfo};
-use term_size::dimensions_stdout;
+use terminal_size::terminal_size;
 use tr::tr;
 use unicode_width::UnicodeWidthStr;
 
@@ -172,7 +172,8 @@ pub fn print_custom_info(
     len: usize,
 ) -> Result<(), Error> {
     let color = conf.color;
-    let cols = dimensions_stdout().map(|x| x.0);
+    let cols = terminal_size().map(|(w, _)| w.0 as usize);
+
     let print = |k: &str, v: &str| print(color, len, cols, k, v);
     let print_list = |k: &str, v: &[_]| print_list(color, len, cols, k, v);
     let print_arch_list = |k: &str, v: &[ArchVec]| {
@@ -238,7 +239,7 @@ pub fn print_aur_info(
     len: usize,
 ) -> Result<(), Error> {
     let color = conf.color;
-    let cols = dimensions_stdout().map(|x| x.0);
+    let cols = terminal_size().map(|(w, _)| w.0 as usize);
     let print = |k: &str, v: &str| print(color, len, cols, k, v);
     let print_list = |k: &str, v: &[_]| print_list(color, len, cols, k, v);
     let no = tr!("No");


### PR DESCRIPTION
`term_size` crate is now unmaintained. This PR replaces it with `terminal_size` as the maintainers say.

https://github.com/clap-rs/term_size-rs

> This crate is no longer maintained. It works fine, but the maintainers don't have time and willingness to work on it or review future PRs anymore.
> 
> Consider using [terminal_size](https://github.com/eminence/terminal-size/) instead.