### PR TITLE
Don't try to parse devel.json if it's empty

### DIFF
--- a/src/devel.rs
+++ b/src/devel.rs
@@ -473,7 +473,14 @@ pub async fn fetch_devel_info(
 
 pub fn load_devel_info(config: &Config) -> Result<Option<DevelInfo>> {
     let file = match OpenOptions::new().read(true).open(&config.devel_path) {
-        Ok(file) => file,
+        Ok(file) => {
+            if let Ok(metadata) = file.metadata() {
+                if metadata.len() == 0 {
+                    return Ok(None)
+                }
+            }
+            file
+        },
         _ => return Ok(None),
     };
     let devel_info = serde_json::from_reader(file)


### PR DESCRIPTION
In rare scenarios with low disk space left, running `paru -Syu --devel` could cause an abrupt interruption, due to 'No space left on device (os error 28)':

![image](https://user-images.githubusercontent.com/626206/192129468-aabea4df-0675-497d-9fc6-ca85706d8e58.png)

In that scenario, the original `devel.json` could be replaced by an empty file, which would cause `paru` to fail on future `--devel` updates, due to not being able to parse an empty file as json:

![image](https://user-images.githubusercontent.com/626206/192129455-a7c83f4b-538f-49e8-9ecf-0e263cdd7f36.png)

This fixes the issue by simply ignoring `devel.json` when it's empty.