### PR TITLE
Add BottomUp=auto config option

### DIFF
--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -25,8 +25,9 @@ your user's config and then defining options.
 Options belonging to the [options] section.
 
 .TP
-.B BottomUp
-Print search results from bottom to top. AUR results will be printed first.
+.B BottomUp [= auto]
+Print search results from bottom to top. AUR results will be printed first. If
+set to auto, only prints results from bottom to top if standard output is a tty.
 
 .TP
 .B AurOnly

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -27,7 +27,8 @@ Options belonging to the [options] section.
 .TP
 .B BottomUp [= auto]
 Print search results from bottom to top. AUR results will be printed first. If
-set to auto, only prints results from bottom to top if standard output is a tty.
+set to auto, prints results from bottom to top if standard output is a tty,
+otherwise top to bottom.
 
 .TP
 .B AurOnly

--- a/src/config.rs
+++ b/src/config.rs
@@ -280,8 +280,7 @@ impl SortMode {
                 true => SortMode::BottomUp,
                 false => SortMode::TopDown,
             }
-        }
-        else {
+        } else {
             *self
         }
     }
@@ -291,7 +290,7 @@ impl ConfigEnum for SortMode {
     const VALUE_LOOKUP: ConfigEnumValues<Self> = &[
         ("bottomup", Self::BottomUp),
         ("topdown", Self::TopDown),
-        ("auto", Self::Auto)
+        ("auto", Self::Auto),
     ];
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -272,6 +272,21 @@ pub enum SortMode {
     Auto,
 }
 
+impl SortMode {
+    //! Turns [SortMode::Auto] into one of the other variants.
+    fn resolve(&self) -> Self {
+        if matches!(self, SortMode::Auto) {
+            match isatty(stdout().as_raw_fd()).unwrap_or(false) {
+                true => SortMode::BottomUp,
+                false => SortMode::TopDown,
+            }
+        }
+        else {
+            self.clone()
+        }
+    }
+}
+
 impl ConfigEnum for SortMode {
     const VALUE_LOOKUP: ConfigEnumValues<Self> = &[
         ("bottomup", Self::BottomUp),

--- a/src/config.rs
+++ b/src/config.rs
@@ -274,7 +274,7 @@ pub enum SortMode {
 
 impl SortMode {
     //! Turns [SortMode::Auto] into one of the other variants.
-    fn resolve(&self) -> Self {
+    pub fn resolve(&self) -> Self {
         if matches!(self, SortMode::Auto) {
             match isatty(stdout().as_raw_fd()).unwrap_or(false) {
                 true => SortMode::BottomUp,
@@ -282,7 +282,7 @@ impl SortMode {
             }
         }
         else {
-            self.clone()
+            *self
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -276,7 +276,7 @@ impl SortMode {
     //! Turns [SortMode::Auto] into one of the other variants.
     pub fn resolve(&self) -> Self {
         if matches!(self, SortMode::Auto) {
-            match isatty(stdout().as_raw_fd()){
+            match isatty(stdout().as_raw_fd()) {
                 Ok(true) => SortMode::BottomUp,
                 _ => SortMode::TopDown,
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -276,9 +276,9 @@ impl SortMode {
     //! Turns [SortMode::Auto] into one of the other variants.
     pub fn resolve(&self) -> Self {
         if matches!(self, SortMode::Auto) {
-            match isatty(stdout().as_raw_fd()).unwrap_or(false) {
-                true => SortMode::BottomUp,
-                false => SortMode::TopDown,
+            match isatty(stdout().as_raw_fd()){
+                Ok(true) => SortMode::BottomUp,
+                _ => SortMode::TopDown,
             }
         } else {
             *self

--- a/src/config.rs
+++ b/src/config.rs
@@ -269,11 +269,15 @@ impl ConfigEnum for raur::SearchBy {
 pub enum SortMode {
     BottomUp,
     TopDown,
+    Auto,
 }
 
 impl ConfigEnum for SortMode {
-    const VALUE_LOOKUP: ConfigEnumValues<Self> =
-        &[("bottomup", Self::BottomUp), ("topdown", Self::TopDown)];
+    const VALUE_LOOKUP: ConfigEnumValues<Self> = &[
+        ("bottomup", Self::BottomUp),
+        ("topdown", Self::TopDown),
+        ("auto", Self::Auto)
+    ];
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -950,7 +954,7 @@ impl Config {
 
         match key {
             "SkipReview" => self.skip_review = true,
-            "BottomUp" => self.sort_mode = SortMode::BottomUp,
+            "BottomUp" => self.sort_mode = SortMode::BottomUp.default_or(key, value)?,
             "AurOnly" => self.mode = Mode::Aur,
             "RepoOnly" => self.mode = Mode::Repo,
             "SudoLoop" => {
@@ -1017,6 +1021,7 @@ impl Config {
             "AurUrl" => self.aur_url = value?.parse()?,
             "AurRpcUrl" => self.aur_rpc_url = Some(value?.parse()?),
             "BuildDir" | "CloneDir" => self.build_dir = PathBuf::from(value?),
+            "BottomUp" => self.sort_mode = ConfigEnum::from_str(key, value?.as_str())?,
             "Redownload" => self.redownload = ConfigEnum::from_str(key, value?.as_str())?,
             "Rebuild" => self.rebuild = ConfigEnum::from_str(key, value?.as_str())?,
             "RemoveMake" => self.remove_make = ConfigEnum::from_str(key, value?.as_str())?,

--- a/src/download.rs
+++ b/src/download.rs
@@ -488,7 +488,7 @@ pub async fn show_comments(config: &mut Config) -> Result<i32> {
 
         let iter = titles.zip(comments).collect::<Vec<_>>();
 
-        if config.sort_mode == SortMode::TopDown {
+        if config.sort_mode.resolve() == SortMode::TopDown {
             for (title, comment) in iter.into_iter() {
                 print_indent(c.bold, 0, 0, config.cols, " ", title.split_whitespace());
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -56,7 +56,7 @@ pub async fn search(config: &Config) -> Result<i32> {
         }
     };
 
-    if config.sort_mode == SortMode::TopDown {
+    if config.sort_mode.resolve() == SortMode::TopDown {
         for pkg in &repo_pkgs {
             print_alpm_pkg(config, pkg, quiet);
         }
@@ -434,7 +434,7 @@ pub async fn search_install(config: &mut Config) -> Result<i32> {
         all_pkgs.insert(0, pkg);
     }
 
-    if config.sort_mode == SortMode::TopDown {
+    if config.sort_mode.resolve() == SortMode::TopDown {
         for (n, pkg) in all_pkgs.iter().enumerate() {
             print_any_pkg(config, n, pad, pkg, &paths)
         }
@@ -454,7 +454,7 @@ pub async fn search_install(config: &mut Config) -> Result<i32> {
     let menu = NumberMenu::new(&input);
     let mut pkgs = Vec::new();
 
-    if config.sort_mode == SortMode::TopDown {
+    if config.sort_mode.resolve() == SortMode::TopDown {
         for (n, pkg) in all_pkgs.iter().enumerate() {
             if menu.contains(n + 1, "") {
                 match pkg {


### PR DESCRIPTION
Prints bottom-to-top if connected to a tty, top-to-bottom otherwise. I've tested all 3 configurations locally (`BottomUp`, `#BottomUp`, `BottomUp=auto`) and they all work as I expect them to, and `cargo fmt --check` and the test suite both succeed.