### PR TITLE
Change return code for the case when no news is printed

### DIFF
--- a/src/news.rs
+++ b/src/news.rs
@@ -67,10 +67,8 @@ pub async fn news(config: &Config) -> Result<i32> {
 
     if !printed {
         eprintln!("{}", tr!("no new news"));
-        Ok(1)
-    } else {
-        Ok(0)
     }
+    Ok(0)
 }
 
 fn parse_html(config: &Config, html: &str) {


### PR DESCRIPTION
An exit code of 1 indicates that the command ran with a failure. It successfully determined there was no news, so should use an exit code of 0.

This exit code 1 behavior seems to cause issues with topgrade, see https://github.com/topgrade-rs/topgrade/issues/232 and https://github.com/topgrade-rs/topgrade/issues/220.