### PR TITLE
Fix message on how to download custom repos

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -1050,9 +1050,9 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr "el pkgbase {base} ja existeix al dipòsit {repo} -- s'omet) "
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
-"el dipòsit {} no s'ha descarregat (utilitzeu -Sya per a descarregar-lo)"
+"el dipòsit {} no s'ha descarregat (utilitzeu --pkgbuilds -Sy per a descarregar-lo)"
 
 #: src/install.rs:2284
 msgid "repo {} does not have a URL or Path"

--- a/po/de.po
+++ b/po/de.po
@@ -1059,8 +1059,8 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr "pkgbase {base} existiert bereits in Repo {repo} -- überspringe)"
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
-msgstr "Repo {} nicht heruntergeladen (benutze -Sya zum Herunterladen)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
+msgstr "Repo {} nicht heruntergeladen (benutze --pkgbuilds -Sy zum Herunterladen)"
 
 #: src/install.rs:2284
 msgid "repo {} does not have a URL or Path"

--- a/po/es.po
+++ b/po/es.po
@@ -1076,7 +1076,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/po/fi.po
+++ b/po/fi.po
@@ -1014,7 +1014,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/po/fr.po
+++ b/po/fr.po
@@ -1073,7 +1073,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/po/hi.po
+++ b/po/hi.po
@@ -1014,7 +1014,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/po/hr.po
+++ b/po/hr.po
@@ -1041,7 +1041,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/po/it.po
+++ b/po/it.po
@@ -1017,7 +1017,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/po/ja.po
+++ b/po/ja.po
@@ -1038,7 +1038,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/po/ko.po
+++ b/po/ko.po
@@ -1030,7 +1030,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/po/nl.po
+++ b/po/nl.po
@@ -1064,8 +1064,8 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr "pkgbase {base} is al onderdeel van repo {repo} -- overslaan"
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
-msgstr "repo {} niet gedownload (gebruik -Sya om te downloaden)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
+msgstr "repo {} niet gedownload (gebruik --pkgbuilds -Sy om te downloaden)"
 
 #: src/install.rs:2284
 msgid "repo {} does not have a URL or Path"

--- a/po/paru.pot
+++ b/po/paru.pot
@@ -960,7 +960,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/po/pt.po
+++ b/po/pt.po
@@ -1047,8 +1047,8 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr "pkgbase {base} já existe no repositório {repo} -- a ignorar)"
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
-msgstr "repositório {} não transferido (use -Sya para transferir)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
+msgstr "repositório {} não transferido (use --pkgbuilds -Sy para transferir)"
 
 #: src/install.rs:2284
 msgid "repo {} does not have a URL or Path"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1050,8 +1050,8 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr "pkgbase {base} já existe no repositório {repo} -- ignorando)"
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
-msgstr "repositório {} não baixado (use -Sya para baixar)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
+msgstr "repositório {} não baixado (use --pkgbuilds -Sy para baixar)"
 
 #: src/install.rs:2284
 msgid "repo {} does not have a URL or Path"

--- a/po/ro.po
+++ b/po/ro.po
@@ -1012,7 +1012,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/po/ru.po
+++ b/po/ru.po
@@ -1013,7 +1013,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/po/sv.po
+++ b/po/sv.po
@@ -1040,7 +1040,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/po/tr.po
+++ b/po/tr.po
@@ -1013,7 +1013,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -997,8 +997,8 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr "软件包组 {base} 在软件库 {repo} 中已经存在 -- 跳过安装)"
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
-msgstr "软件库 {} 没有被下载 (使用 -Sya 下载)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
+msgstr "软件库 {} 没有被下载 (使用 --pkgbuilds -Sy 下载)"
 
 #: src/install.rs:2284
 msgid "repo {} does not have a URL or Path"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1009,7 +1009,7 @@ msgid "pkgbase {base} already exists in repo {repo} -- skipping)"
 msgstr ""
 
 #: src/install.rs:2267
-msgid "repo {} not downloaded (use -Sya to download)"
+msgid "repo {} not downloaded (use --pkgbuilds -Sy to download)"
 msgstr ""
 
 #: src/install.rs:2284

--- a/src/install.rs
+++ b/src/install.rs
@@ -2303,7 +2303,7 @@ pub fn refresh_custom_repos(config: &Config, fetch: &Fetch) -> Result<()> {
                 eprintln!(
                     "{} {}",
                     c.warning.paint("::"),
-                    tr!("repo {} not downloaded (use -Sya to download)", repo.name)
+                    tr!("repo {} not downloaded (use --pkgbuilds -Sy to download)", repo.name)
                 );
             }
         }


### PR DESCRIPTION
`-Sya` sets the mode to aur, while pkgbuilds mode is necessary for it to actually download the repos. This updates the warning message to reflect this (as well as all of the localization files). Not entirely sure whether it's better to put `--pkgbuilds` before or after `-Sy`, and whether it should be somehow quoted (probably with backticks) since it now has multiple words.

I think that it would be nice to have a shorter way to specify pkgbuilds mode than `--pkgbuilds` (funnily enough, `--mode=p` is actually shorter, but I think that it's not as intuitive). `-p` doesn't work since it's already used for a "dry-run" (`--print`) by pacman.