### PR TITLE
Fix the default value of `Provides`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -445,7 +445,7 @@ pub struct Config {
     pub no_confirm: bool,
     pub devel: bool,
     pub clean_after: bool,
-    #[default(YesNoAll::No)]
+    #[default(YesNoAll::Yes)]
     pub provides: YesNoAll,
     pub pgp_fetch: bool,
     pub combined_upgrade: bool,


### PR DESCRIPTION
The default value of `Provides` should be `Yes` according to the manual and the parsing logic.
https://github.com/Morganamilo/paru/blob/257e01155501e3f93ed218f3853156a030b20c58/man/paru.conf.5#L105
https://github.com/Morganamilo/paru/blob/257e01155501e3f93ed218f3853156a030b20c58/src/config.rs#L1042

This might fix https://github.com/Morganamilo/paru/issues/747#issuecomment-1527014428 .