### PR TITLE
Suggest `SigLevel = Never` when prompting user to add local repo to pacman.conf

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -800,7 +800,7 @@ impl Config {
     CacheDir = /var/lib/repo/aur
 
     [aur]
-    SigLevel = PackageOptional DatabaseOptional
+    SigLevel = Never
     Server = file:///var/lib/repo/aur"
                 );
             }


### PR DESCRIPTION
Currently, when using the local repo option, paru's help text suggests setting `SigLevel` to `PackageOptional DatabaseOptional`, along with adding the local repo as an additional `CacheDir` to avoid unnecessary copies to `/var/cache/pacman/pkg`. Unfortunately, since pacman 6, this doesn't actually work when packages are unsigned. With optional signatures, if pacman can't find the `.sig` in the cache, it triggers the download logic, causing the local packages to be copied to the first listed `CacheDir`.

Since most users are unlikely to sign their locally-built AUR packages, it probably makes the most sense to have the help text suggest setting `SigLevel` to `Never` instead, which avoids this problem since pacman won't try to look for the `.sig` in the cache. Folks who sign their packages are unaffected regardless of the `SigLevel` value since there's never a situation where a file would be "missing" from the cache.

[1] https://bugs.archlinux.org/task/71109