### PR TITLE
Man for paru.conf didn't display properly

### DIFF
--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -1,4 +1,4 @@
-..TH "PARU.CONF" "5" "2021\-03\-24" "paru v1.10.0" "Paru Manual"
+.TH "PARU.CONF" "5" "2021\-03\-24" "paru v1.10.0" "Paru Manual"
 .nh
 .ad l
 .SH NAME


### PR DESCRIPTION
https://github.com/Morganamilo/paru/commit/75f46a8a6b047dc8b197cb5832cbe59a8d683dfc caused `man paru.conf` to not display propely (flags not visible in output)