### PR TITLE
Fix deprecated `from_utc`

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -25,13 +25,13 @@ pub fn opt(opt: &Option<String>) -> String {
 
 pub fn date(date: i64) -> String {
     let date = NaiveDateTime::from_timestamp_opt(date, 0).unwrap();
-    let date = DateTime::<chrono::Utc>::from_utc(date, chrono::Utc);
+    let date = DateTime::<chrono::Utc>::from_naive_utc_and_offset(date, chrono::Utc);
     date.to_rfc2822()
 }
 
 pub fn ymd(date: i64) -> String {
     let date = NaiveDateTime::from_timestamp_opt(date, 0).unwrap();
-    let date = DateTime::<chrono::Utc>::from_utc(date, chrono::Utc);
+    let date = DateTime::<chrono::Utc>::from_naive_utc_and_offset(date, chrono::Utc);
     date.format("%Y-%m-%d").to_string()
 }
 


### PR DESCRIPTION
A no-brainer, really. Even the bodies of those functions are the same. It's just that `from_utc` wasn't verbose enough, so now it's deprecated and they ask you to use `from_naive_utc_and_offset` instead.

Makes cargo shut up about the use of a deprecated function.