### PR TITLE
Add news_url in config.rs

### DIFF
--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -135,8 +135,9 @@ are built or a package in the build queue is needed as a dependency to build
 another package, install all the packages in the install queue.
 
 .TP
-.B NewsOnUpgrade
-Print new news during sysupgrade.
+.B NewsOnUpgrade [= URL]
+Print new news during sysupgrade. By default paru fetches news from the Arch Linux
+RSS news feed. Users of other distributions can customize the RSS feed URL here.
 
 .TP
 .B UseAsk

--- a/src/config.rs
+++ b/src/config.rs
@@ -416,6 +416,8 @@ pub struct Config {
     pub aur_rpc_url: Option<Url>,
     #[default(Url::parse("https://archlinux.org").unwrap())]
     pub arch_url: Url,
+    #[default(Url::parse("https://archlinux.org/feeds/news/").unwrap())]
+    pub news_url: Url,
     pub build_dir: PathBuf,
     pub cache_dir: PathBuf,
     pub state_dir: PathBuf,
@@ -1056,7 +1058,12 @@ impl Config {
             "BatchInstall" => self.batch_install = true,
             "UseAsk" => self.use_ask = true,
             "SaveChanges" => self.save_changes = true,
-            "NewsOnUpgrade" => self.news_on_upgrade = true,
+            "NewsOnUpgrade" => {
+                self.news_on_upgrade = true;
+                if let Some(l) = value {
+                    self.news_url = l.parse()?;
+                }
+            }
             "InstallDebug" => self.install_debug = true,
             "Redownload" => self.redownload = YesNoAll::Yes.default_or(key, value)?,
             "Rebuild" => self.rebuild = YesNoAllTree::Yes.default_or(key, value)?,

--- a/src/news.rs
+++ b/src/news.rs
@@ -30,7 +30,7 @@ pub fn newest_pkg(config: &Config) -> i64 {
 }
 
 pub async fn news(config: &Config) -> Result<i32> {
-    let url = config.arch_url.join("feeds/news")?;
+    let url = &config.news_url;
     let client = config.raur.client();
 
     let resp = client.get(url.clone()).send().await?;


### PR DESCRIPTION
This PR allows the user to specify which rss feed to fetch news from by specifying a URL after NewsOnUpgrade. This can be useful for users of other pacman-based distros.