### PR TITLE
Add printing of which package failed to clean in aur cache

### DIFF
--- a/src/clean.rs
+++ b/src/clean.rs
@@ -94,16 +94,18 @@ fn clean_aur(
     let cached_pkgs = read_dir(&config.fetch.clone_dir)
         .with_context(|| tr!("can't open clone dir: {}", config.fetch.clone_dir.display()))?;
 
-    #[allow(unused_must_use)]
-    cached_pkgs.for_each(|maybe_pkg| {
-        maybe_pkg.map_err(anyhow::Error::from).map(|path| {
-            clean_aur_pkg(config, &path, remove_all, keep_installed, keep_current, rm).map_err(
-                |err| {
-                    print_error(config.color.error, err);
-                },
-            );
-        });
-    });
+    for maybe_pkg in cached_pkgs {
+        if let Err(err) = clean_aur_pkg(
+            config,
+            &maybe_pkg?,
+            remove_all,
+            keep_installed,
+            keep_current,
+            rm,
+        ) {
+            print_error(config.color.error, err);
+        }
+    }
 
     Ok(())
 }

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -94,16 +94,12 @@ fn clean_aur(
     let cached_pkgs = read_dir(&config.fetch.clone_dir)
         .with_context(|| tr!("can't open clone dir: {}", config.fetch.clone_dir.display()))?;
 
-    for maybe_pkg in cached_pkgs {
-        if let Err(err) = clean_aur_pkg(
-            config,
-            &maybe_pkg?,
-            remove_all,
-            keep_installed,
-            keep_current,
-            rm,
-        ) {
+    for file in cached_pkgs {
+        if let Err(err) =
+            clean_aur_pkg(config, &file?, remove_all, keep_installed, keep_current, rm)
+        {
             print_error(config.color.error, err);
+            continue;
         }
     }
 

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -99,8 +99,15 @@ fn clean_aur(
         maybe_pkg.map_err(anyhow::Error::from).map(|path| {
             clean_aur_pkg(config, &path, remove_all, keep_installed, keep_current, rm).map_err(
                 |err| {
+                    let msg_start = tr!("Failed to clean package");
                     let name = path.file_name();
-                    printtr!("Failed to clean package: {}", name.to_string_lossy());
+                    let msg_body = name.to_string_lossy();
+                    eprintln!(
+                        "{} {}: {}",
+                        config.color.error.paint("::"),
+                        config.color.bold.paint(&msg_start),
+                        msg_body,
+                    );
                     print_error(config.color.error, err);
                 },
             );


### PR DESCRIPTION
I recently installed a package from the AUR that `srcinfo.rs` failed to parse the `.SRCINFO` of. As a result, when I attempted to clean the caches (with `paru -Sc`), I get an error message of the parse failure, but there is no indication of which package the error originated from. This PR adds that information to the output.

### Before
![2023-11-19-18-12-54](https://github.com/Morganamilo/paru/assets/11096602/48e2613b-67af-4064-ac4e-e7b3e583a2da)
### After
![2023-11-19-18-14-01](https://github.com/Morganamilo/paru/assets/11096602/4a86fd2b-c51e-4df1-aac5-4f91ef966d61)