### PR TITLE
Add chrootflags option

### DIFF
--- a/completions/bash
+++ b/completions/bash
@@ -70,8 +70,8 @@ _paru() {
            noconfirm noprogressbar noscriptlet quiet root verbose
 
            repo aur aururl clonedir makepkg mflags pacman pacman-conf git gitflags sudo sudoflags
-           asp gpg gpgflags fm fmflags pager completioninterval sortby searchby limit upgrademenu
-           removemake noremovemake cleanafter nocleanafter rebuild rebuildall norebuild
+           asp gpg gpgflags fm fmflags chrootflags pager completioninterval sortby searchby limit
+           upgrademenu removemake noremovemake cleanafter nocleanafter rebuild rebuildall norebuild
            rebuildtree redownload noredownload redownloadall pgpfetch nopgpfetch useask
            nouseask savechanges nosavechanges failfast nofailfast keepsrc nokeepsrc combinedupgrade
            nocombinedupgrade batchinstall nobatchinstall provides noprovides devel nodevel

--- a/completions/fish
+++ b/completions/fish
@@ -241,6 +241,7 @@ complete -c $progname -n "not $noopt" -l gpgflags -d 'Pass the following options
 complete -c $progname -n "not $noopt" -l sudoflags -d 'Pass the following options to sudo' -f
 complete -c $progname -n "not $noopt" -l batflags -d 'Pass the following options to sudo' -f
 complete -c $progname -n "not $noopt" -l fmflags -d 'Pass the following options to file manager' -f
+complete -c $progname -n "not $noopt" -l chrootflags -d 'Pass the following options to makechrootpkg' -f
 complete -c $progname -n "not $noopt" -l sudoloop -d 'Loop sudo calls in the background to avoid timeout' -f
 complete -c $progname -n "not $noopt" -l nosudoloop -d 'Do not loop sudo calls in the background' -f
 complete -c $progname -n "not $noopt" -l chroot -d 'Build packages in a chroot' -f

--- a/completions/zsh
+++ b/completions/zsh
@@ -100,6 +100,7 @@ _pacman_opts_common=(
 	'--batflags[Pass arguments to bat]:flags'
 	'--gpgflags[Pass arguments to gpg]:flags'
 	'--fmflags[Pass arguments to file manager]:flags'
+	'--chrootflags[Pass arguments to makechrootpkg]:flags'
 
 	'--sudoloop[Loop sudo calls in the background to avoid timeout]'
 	'--nosudoloop[Do not loop sudo calls in the background]'

--- a/man/paru.8
+++ b/man/paru.8
@@ -395,6 +395,13 @@ passed to sudo. Multiple arguments may be passed by supplying a space
 separated list that is quoted by the shell.
 
 .TP
+.B \-\-chrootflags <flags>
+Passes arguments to makechrootpkg. These flags get passed to every instance
+where makechrootpkg is called by paru. Arguments are split on whitespace before
+being passed to makechrootpkg. Multiple arguments may be passed by supplying a
+space separated list that is quoted by the shell.
+
+.TP
 .B \-\-completioninterval <days>
 Time in days to refresh the completion cache. Setting this to 0 will cause the
 cache to be refreshed every time, while setting this to -1 will cause the cache

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -357,6 +357,12 @@ where file manager is called by paru. Arguments are split on whitespace before
 being passed to file manager.
 
 .TP
+.B ChrootFlags = Flags...
+Passes arguments to makechrootpkg. These flags get passed to every instance
+where makechrootpkg is called by paru. Arguments are split on whitespace before
+being passed to makechrootpkg.
+
+.TP
 .B Pager = Command
 Command to use for paging
 

--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -101,11 +101,11 @@ impl Chroot {
         self.run(&["pacman", "-Syu", "--noconfirm"])
     }
 
-    pub fn build(
+    pub fn build<S: AsRef<OsStr>>(
         &self,
         pkgbuild: &Path,
         pkgs: &[&str],
-        chroot_flags: &[&str],
+        chroot_flags: &[S],
         flags: &[&str],
         env: &[(String, String)],
     ) -> Result<()> {

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -194,6 +194,7 @@ impl Config {
             Arg::Long("sudoflags") => self.sudo_flags.extend(split_whitespace(value?)),
             Arg::Long("batflags") => self.bat_flags.extend(split_whitespace(value?)),
             Arg::Long("fmflags") => self.fm_flags.extend(split_whitespace(value?)),
+            Arg::Long("chrootflags") => self.chroot_flags.extend(split_whitespace(value?)),
 
             Arg::Long("develsuffixes") => self.devel_suffixes = split_whitespace(value?),
             Arg::Long("installdebug") => self.install_debug = true,
@@ -406,6 +407,7 @@ fn takes_value(arg: Arg) -> TakesValue {
         Arg::Long("sudoflags") => TakesValue::Required,
         Arg::Long("batflags") => TakesValue::Required,
         Arg::Long("fmflags") => TakesValue::Required,
+        Arg::Long("chrootflags") => TakesValue::Required,
         Arg::Long("completioninterval") => TakesValue::Required,
         Arg::Long("sortby") => TakesValue::Required,
         Arg::Long("searchby") => TakesValue::Required,

--- a/src/config.rs
+++ b/src/config.rs
@@ -503,6 +503,7 @@ pub struct Config {
     pub sudo_flags: Vec<String>,
     pub bat_flags: Vec<String>,
     pub fm_flags: Vec<String>,
+    pub chroot_flags: Vec<String>,
     pub pager_cmd: Option<String>,
 
     pub devel_suffixes: Vec<String>,
@@ -1020,6 +1021,7 @@ impl Config {
             "SudoFlags" => self.sudo_flags.extend(split),
             "BatFlags" => self.bat_flags.extend(split),
             "FileManagerFlags" => self.fm_flags.extend(split),
+            "ChrootFlags" => self.chroot_flags.extend(split),
             "PreBuildCommand" => self.pre_build_command = Some(value),
             _ => eprintln!(
                 "{}",

--- a/src/install.rs
+++ b/src/install.rs
@@ -510,8 +510,11 @@ impl Installer {
             if config.repos == LocalRepos::None {
                 extra.extend(self.built.iter().map(|s| s.as_str()));
             }
+            let mut chroot_flags: Vec<&str> =
+                config.chroot_flags.iter().map(|s| s.as_str()).collect();
+            chroot_flags.push("-cu");
             self.chroot
-                .build(dir, &extra, &["-cu"], &["-ofA"], &config.env)
+                .build(dir, &extra, &chroot_flags, &["-ofA"], &config.env)
                 .with_context(|| tr!("failed to download sources for '{}'"))?;
         } else {
             // download sources
@@ -554,7 +557,7 @@ impl Installer {
                     .build(
                         dir,
                         &extra,
-                        &[],
+                        &config.chroot_flags,
                         &["-feA", "--noconfirm", "--noprepare", "--holdver"],
                         &env,
                     )


### PR DESCRIPTION
# Use case
These flags can be used to configure ccache for chroot.
See https://wiki.archlinux.org/title/ccache#makechrootpkg for details.

Example configuration:
```
[env]
CCACHE_DIR=/ccache

[bin]
ChrootFlags = -d /home/mike/.cache/ccache:/ccache
```

Related: https://github.com/Morganamilo/paru/issues/983#issuecomment-1657115394