### PR TITLE
Aur packages could be installed as needed

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -2042,14 +2042,14 @@ fn needs_build(
             if !base
                 .packages()
                 .filter_map(|p| repos.pkg(p).ok())
-                .any(|_| base.version() == version)
+                .any(|p| p.version() == version)
             {
                 all_installed = false
             }
         } else if !base
             .packages()
             .filter_map(|p| config.alpm.localdb().pkg(p).ok())
-            .any(|_| base.version() == version)
+            .any(|p| p.version() == version)
         {
             all_installed = false
         }


### PR DESCRIPTION
Fix #1093

paru should always retrieve package info from local package database instead of aur repo.