### PR TITLE
Fix cache_dir instead of state_dir in error message

### DIFF
--- a/src/devel.rs
+++ b/src/devel.rs
@@ -216,7 +216,7 @@ pub fn save_devel_info(config: &Config, devel_info: &DevelInfo) -> Result<()> {
     create_dir_all(&config.state_dir).with_context(|| {
         tr!(
             "failed to create state directory: {}",
-            config.cache_dir.display()
+            config.state_dir.display()
         )
     })?;
 


### PR DESCRIPTION
This PR makes the `failed to create state directory` error display the proper directory, as it can be quite confusing when it happens.