### PR TITLE
Refactor code for readability and efficiency

### DIFF
--- a/scripts/mkmo
+++ b/scripts/mkmo
@@ -7,7 +7,7 @@ if [ -z "$1" ]; then
 fi
 
 for po in po/*.po; do
-	lang=$(basename ${po%.po})
+	lang=$(basename "${po%.po}")
 	install -dm755 "$1/$lang/LC_MESSAGES/"
 	msgfmt "$po" -o "$1/$lang/LC_MESSAGES/paru.mo"
 done

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -106,12 +106,12 @@ impl Config {
             while let Some(c) = chars.next() {
                 let arg = Arg::Short(c);
                 if takes_value(arg) == TakesValue::Required {
-                    if chars.as_str().is_empty() {
+                    return if chars.as_str().is_empty() {
                         self.handle_arg(arg, value, op_count, false)?;
-                        return Ok(true);
+                        Ok(true)
                     } else {
                         self.handle_arg(arg, Some(chars.as_str()), op_count, false)?;
-                        return Ok(false);
+                        Ok(false)
                     }
                 }
                 self.handle_arg(arg, None, op_count, false)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -696,11 +696,11 @@ impl Config {
         }
 
         self.args.op = self.op.as_str().to_string();
-        self.args.targets = self.targets.clone();
-        self.args.bin = self.pacman_bin.clone();
+        self.args.targets.clone_from(&self.targets);
+        self.args.bin.clone_from(&self.pacman_bin);
 
         self.globals.op = self.op.as_str().to_string();
-        self.globals.bin = self.pacman_bin.clone();
+        self.globals.bin.clone_from(&self.pacman_bin);
 
         if self.help {
             match self.op {
@@ -848,7 +848,7 @@ impl Config {
         )?;
 
         if let Some(ref dbpath) = self.db_path {
-            self.pacman.db_path = dbpath.clone();
+            self.pacman.db_path.clone_from(dbpath);
         }
 
         self.ignore.extend(self.pacman.ignore_pkg.clone());

--- a/src/devel.rs
+++ b/src/devel.rs
@@ -10,7 +10,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs::{create_dir_all, read_to_string, OpenOptions};
 use std::hash::{Hash, Hasher};
 use std::io::Write;
-use std::iter::FromIterator;
 use std::time::Duration;
 
 use alpm_utils::{DbListExt, Target};
@@ -59,7 +58,7 @@ impl Ord for RepoInfo {
     }
 }
 
-impl std::cmp::PartialEq for RepoInfo {
+impl PartialEq for RepoInfo {
     fn eq(&self, other: &Self) -> bool {
         self.url == other.url && self.branch == other.branch
     }
@@ -348,7 +347,7 @@ pub async fn possible_devel_updates(config: &Config) -> Result<Vec<String>> {
     let mut pkgbases: HashMap<&str, Vec<&alpm::Package>> = HashMap::new();
 
     for pkg in db.pkgs().iter() {
-        let name = pkg_base_or_name(&pkg);
+        let name = pkg_base_or_name(pkg);
         pkgbases.entry(name).or_default().push(pkg);
     }
 
@@ -411,12 +410,12 @@ pub async fn filter_devel_updates(
 
     let (_, dbs) = repo::repo_aur_dbs(config);
     for pkg in dbs.iter().flat_map(|d| d.pkgs()) {
-        let name = pkg_base_or_name(&pkg);
+        let name = pkg_base_or_name(pkg);
         pkgbases.entry(name).or_default().push(pkg);
     }
 
     for pkg in db.pkgs().iter() {
-        let name = pkg_base_or_name(&pkg);
+        let name = pkg_base_or_name(pkg);
         pkgbases.entry(name).or_default().push(pkg);
     }
 
@@ -571,19 +570,19 @@ pub fn load_devel_info(config: &Config) -> Result<Option<DevelInfo>> {
     }
 
     for pkg in config.alpm.localdb().pkgs().iter() {
-        let name = pkg_base_or_name(&pkg);
+        let name = pkg_base_or_name(pkg);
         pkgbases.entry(name).or_default().push(pkg);
     }
 
     let (_, dbs) = repo::repo_aur_dbs(config);
     for pkg in dbs.iter().flat_map(|d| d.pkgs()) {
-        let name = pkg_base_or_name(&pkg);
+        let name = pkg_base_or_name(pkg);
         pkgbases.entry(name).or_default().push(pkg);
     }
 
     devel_info
         .info
-        .retain(|pkg, _| pkgbases.get(pkg.as_str()).is_some());
+        .retain(|pkg, _| pkgbases.contains_key(pkg.as_str()));
 
     save_devel_info(config, &devel_info)?;
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -5,7 +5,6 @@ use crate::RaurHandle;
 
 use std::collections::HashMap;
 use std::io::Write;
-use std::iter::FromIterator;
 use std::process::{Command, Stdio};
 use std::result::Result as StdResult;
 
@@ -238,7 +237,7 @@ fn repo_pkgbuilds(config: &Config, pkgs: &[Targ<'_>]) -> Result<i32> {
                     "{} {} export {}",
                     tr!("failed to run:"),
                     pkgctl,
-                    targ.to_string()
+                    targ
                 )
             })?;
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -174,7 +174,7 @@ fn wait_for_lock(config: &Config) {
         );
 
         while path.exists() {
-            std::thread::sleep(Duration::from_secs(3));
+            thread::sleep(Duration::from_secs(3));
         }
     }
 }
@@ -201,7 +201,7 @@ pub fn pacman<S: AsRef<str> + Display + Debug>(config: &Config, args: &Args<S>) 
     command_status(&mut cmd)
 }
 
-pub fn pacman_output<S: AsRef<str> + Display + std::fmt::Debug>(
+pub fn pacman_output<S: AsRef<str> + Display + Debug>(
     config: &Config,
     args: &Args<S>,
 ) -> Result<Output> {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -90,7 +90,7 @@ impl Mock {
 
 #[async_trait]
 impl Raur for Mock {
-    type Err = raur::Error;
+    type Err = Error;
 
     async fn raw_info<S: AsRef<str> + Send + Sync>(
         &self,

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -20,7 +20,7 @@ pub fn remove(config: &mut Config) -> Result<i32> {
         .targets
         .iter()
         .filter_map(|pkg| db.pkg(pkg.as_str()).ok())
-        .map(|pkg| pkg_base_or_name(&pkg))
+        .map(|pkg| pkg_base_or_name(pkg))
         .collect::<Vec<_>>();
 
     let mut db_map: HashMap<String, Vec<String>> = HashMap::new();

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -154,7 +154,7 @@ pub fn all_files(config: &Config) -> Vec<String> {
         .collect()
 }
 
-fn is_local_db(db: &alpm::Db) -> bool {
+fn is_local_db(db: &Db) -> bool {
     !db.servers().is_empty() && db.servers().iter().all(|s| s.starts_with("file://"))
 }
 
@@ -180,13 +180,13 @@ pub fn refresh<S: AsRef<OsStr>>(config: &mut Config, repos: &[S]) -> Result<i32>
     }
 
     for db in dbs {
-        let path = file(&db);
+        let path = file(db);
         if let Some(path) = path {
             init(config, path, db.name())?;
         }
     }
 
-    if !nix::unistd::getuid().is_root() && !cfg!(feature = "mock") {
+    if !unistd::getuid().is_root() && !cfg!(feature = "mock") {
         let mut cmd = Command::new(&config.sudo_bin);
 
         cmd.arg(exe);
@@ -277,7 +277,7 @@ pub fn clean(config: &mut Config) -> Result<i32> {
 
     for pkgs in rem {
         let repo = pkgs[0].db().unwrap();
-        let path = file(&repo).unwrap();
+        let path = file(repo).unwrap();
         let pkgs = pkgs.iter().map(|p| p.name()).collect::<Vec<_>>();
         remove(config, path, repo.name(), &pkgs)?;
     }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -9,7 +9,7 @@ use aur_depends::{Flags, PkgbuildRepo, Resolver};
 use raur::Cache;
 use tr::tr;
 
-pub fn flags(config: &mut Config) -> aur_depends::Flags {
+pub fn flags(config: &mut Config) -> Flags {
     let mut flags = Flags::new();
 
     if config.args.has_arg("needed", "needed") {
@@ -71,7 +71,7 @@ pub fn resolver<'a, 'b>(
     let c = config.color;
     let no_confirm = config.no_confirm;
 
-    let mut resolver = aur_depends::Resolver::new(alpm, cache, raur, flags)
+    let mut resolver = Resolver::new(alpm, cache, raur, flags)
         .pkgbuild_repos(pkgbuild_repos)
         .custom_aur_namespace(Some(config.aur_namespace().to_string()))
         .is_devel(move |pkg| devel_suffixes.iter().any(|suff| pkg.ends_with(suff)))

--- a/src/util.rs
+++ b/src/util.rs
@@ -391,7 +391,7 @@ pub fn split_repo_aur_pkgs<S: AsRef<str> + Clone>(config: &Config, pkgs: &[S]) -
     (repo, aur)
 }
 
-pub fn repo_aur_pkgs(config: &Config) -> (Vec<&alpm::Package>, Vec<&alpm::Package>) {
+pub fn repo_aur_pkgs(config: &Config) -> (Vec<&Package>, Vec<&Package>) {
     if config.repos != LocalRepos::None {
         let (repo, aur) = repo::repo_aur_dbs(config);
         let repo = repo.iter().flat_map(|db| db.pkgs()).collect::<Vec<_>>();


### PR DESCRIPTION
The changes involve simplifying expressions and removing redundancies in different parts of the code, leading to more efficient and readable code. Several changes have been made such as switching from `std::iter::FromIterator` to direct method calls. Other amendments include altering globals to use `clone_from` instead of `clone`, as well as revising instances of package handling, comparison, and other related operations.