### PR TITLE
scripts/mkmo: switch msgfmt args

### DIFF
--- a/scripts/mkmo
+++ b/scripts/mkmo
@@ -9,5 +9,5 @@ fi
 for po in po/*.po; do
 	lang=$(basename ${po%.po})
 	install -dm755 "$1/$lang/LC_MESSAGES/"
-	msgfmt "$po" -o "$1/$lang/LC_MESSAGES/paru.mo"
+	msgfmt -o "$1/$lang/LC_MESSAGES/paru.mo" "$po"
 done


### PR DESCRIPTION
When POSIXLY_CORRECT is set, msgfmt requires options to be specified before the po files (as also defined in its man).