### PR TITLE
delete `use std::iter::FromIterator` to suppress warnings

### DIFF
--- a/src/devel.rs
+++ b/src/devel.rs
@@ -10,7 +10,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs::{create_dir_all, read_to_string, OpenOptions};
 use std::hash::{Hash, Hasher};
 use std::io::Write;
-use std::iter::FromIterator;
 use std::time::Duration;
 
 use alpm_utils::{DbListExt, Target};

--- a/src/download.rs
+++ b/src/download.rs
@@ -5,7 +5,6 @@ use crate::RaurHandle;
 
 use std::collections::HashMap;
 use std::io::Write;
-use std::iter::FromIterator;
 use std::process::{Command, Stdio};
 use std::result::Result as StdResult;
 


### PR DESCRIPTION
Currently, Rust automatically add `std::iter::FromIterator` since prelude of std always included if `#![no_std]` is not enabled.

Thus no need to add `use std::iter::FromIterator`

(actually, that line will trigger 2 warnings:)
```rust
warning: the item `FromIterator` is imported redundantly
   --> src/devel.rs:13:5
    |
13  | use std::iter::FromIterator;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: /home/neutron/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/prelude/mod.rs:129:13
    |
129 |     pub use core::prelude::rust_2021::*;
    |             ------------------------ the item `FromIterator` is already defined here
    |
    = note: `#[warn(unused_imports)]` on by default

warning: the item `FromIterator` is imported redundantly
   --> src/download.rs:8:5
    |
8   | use std::iter::FromIterator;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: /home/neutron/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/prelude/mod.rs:129:13
    |
129 |     pub use core::prelude::rust_2021::*;
    |             ------------------------ the item `FromIterator` is already defined here

warning: `paru` (lib) generated 2 warnings
```

Thus I create this PR to suppress them.