### PR TITLE
fish: autocomplete path when querying the files database

### DIFF
--- a/completions/fish
+++ b/completions/fish
@@ -112,6 +112,7 @@ complete -c $progname -n "$has_db_opt; and $database" -xa "$listinstalled"
 complete -c $progname -n "$files" -s x -l regex -d 'Interpret each query as a regular expression' -f
 complete -c $progname -n "$files" -l machinereadable -d 'Print each match in a machine readable output format' -f
 complete -c $progname -n "$files" -d 'Package' -xa "$listpacman"
+complete -c $progname -n "$files" -F -k
 
 # Query options
 complete -c $progname -n "$query" -s c -l changelog -d 'View the change log of PACKAGE' -f


### PR DESCRIPTION
Enable fish to autocomplete with paths after the package list in `paru -F`, so that tab works as expected. This should help when writing a long path or when locating the file interactively.

Note that `paru -F [TAB]` still lists packages before files, this will be mostly helpful when the user already started a path, `paru -F /[TAB]`.