### PR TITLE
Remove "community" and "community-testing" repo in download.rs

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -462,10 +462,8 @@ fn split_repo_aur_pkgbuilds<'a, T: AsTarg>(
             if matches!(
                 repo,
                 "testing"
-                    | "community-testing"
                     | "core"
                     | "extra"
-                    | "community"
                     | "multilib"
                     | "core-testing"
                     | "extra-testing"
@@ -479,10 +477,8 @@ fn split_repo_aur_pkgbuilds<'a, T: AsTarg>(
             if matches!(
                 pkg.db().unwrap().name(),
                 "testing"
-                    | "community-testing"
                     | "core"
                     | "extra"
-                    | "community"
                     | "multilib"
                     | "core-testing"
                     | "extra-testing"


### PR DESCRIPTION
According to archlinux news [Git migration announcement](https://archlinux.org/news/git-migration-announcement/) and [Git migration completed](https://archlinux.org/news/git-migration-completed/), the [community] repository was merged into [extra].

`community.db` and `community-testing.db` are now empty, it's unnecessary to find packages in it.

