### PR TITLE
Overwrite detach signature

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -2087,7 +2087,7 @@ fn sign_pkg(config: &Config, paths: &[&str], delete_sig: bool) -> Result<()> {
 
         for path in paths {
             let mut cmd = Command::new("gpg");
-            cmd.args(["--detach-sign", "--no-armor", "--batch"]);
+            cmd.args(["--detach-sign", "--no-armor", "--batch", "--yes"]);
 
             if let Sign::Key(ref k) = config.sign {
                 cmd.arg("-u").arg(k);


### PR DESCRIPTION
This change lets gpg overwrite the detached signatures of the packages when the files already exist. Without `--yes`, and in combination with `--batch`, gpg fails (exit 2) without overwriting any file.

Fixes Morganamilo/paru#1256