### PR TITLE
Remove unused crate patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,13 +2613,3 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[patch.unused]]
-name = "alpm"
-version = "3.0.4"
-source = "git+https://github.com/archlinux/alpm.rs?rev=306342#306342efc6f24739c92de64c432f962a22891e63"
-
-[[patch.unused]]
-name = "aur-depends"
-version = "3.0.0"
-source = "git+https://github.com/Morganamilo/aur-depends?rev=30c2c1#30c2c15019f8dd80e803c9deefce3279079806af"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,12 +70,3 @@ static = ["alpm/static"]
 mock = ["async-trait"]
 mock_chroot = ["mock"]
 #default = ["git", "generate"]
-
-[patch.crates-io]
-#alpm = { path = "../alpm.rs/alpm" }
-#alpm-utils = { path = "../alpm.rs/alpm-utils" }
-alpm = { git = "https://github.com/archlinux/alpm.rs", rev = "306342" }
-#alpm-utils = { git = "https://github.com/archlinux/alpm.rs", rev = "8da396" }
-#aur-depends = { path = "../aur-depends" }
-aur-depends = { git = "https://github.com/Morganamilo/aur-depends", rev = "30c2c1"}
-#aur-fetch = { path = "../aur-fetch" }


### PR DESCRIPTION
These patches are not used and cargo gives the following warning when compiling:

```
warning: Patch `alpm v3.0.4 (https://github.com/archlinux/alpm.rs?rev=306342#306342ef)` was not used in the crate graph.
Patch `aur-depends v3.0.0 (https://github.com/Morganamilo/aur-depends?rev=30c2c1#30c2c150)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from
what is locked in the Cargo.lock file, run `cargo update` to use the new
version. This may also occur with an optional dependency that is not enabled.
```