### PR TITLE
chroot: add support for XDG_CONFIG_HOME/pacman/makepkg.conf

### DIFF
--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -92,6 +92,19 @@ impl Chroot {
             cmd.arg(format!("{}.d:/etc/makepkg.conf.d", self.makepkg_conf));
         }
 
+        let xdg_config = std::env::var_os("XDG_CONFIG_HOME")
+            .map(|p| PathBuf::from(p).join("pacman/makepkg.conf"));
+
+        if let Some(xdg_config) = xdg_config {
+            if xdg_config.exists() {
+                cmd.arg("--bind-ro");
+                cmd.arg(format!(
+                    "{}:/etc/makepkg.conf.d/xdg.conf",
+                    xdg_config.display()
+                ));
+            }
+        }
+
         for file in &self.ro {
             cmd.arg("--bind-ro");
             cmd.arg(file);


### PR DESCRIPTION
Allow users to override makepkg.conf settings by placing a config file in $XDG_CONFIG_HOME/pacman/makepkg.conf. When present, this config will be mounted read-only in the chroot at /etc/makepkg.conf.d/xdg.conf, allowing its settings to take precedence over the base config.

Closes #1283