### PR TITLE
fix: handle EOF in user input prompts

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -134,16 +134,27 @@ pub fn ask(config: &Config, question: &str, default: bool) -> bool {
     }
     let stdin = stdin();
     let mut input = String::new();
-    let _ = stdin.read_line(&mut input);
-    let input = input.to_lowercase();
-    let input = input.trim();
+    match stdin.read_line(&mut input) {
+        Ok(0) => {
+            println!(" -> EOF");
+            false
+        }
+        Ok(_) => {
+            let input = input.to_lowercase();
+            let input = input.trim();
 
-    if input == tr!("y") || input == tr!("yes") {
-        true
-    } else if input.trim().is_empty() {
-        default
-    } else {
-        false
+            if input == tr!("y") || input == tr!("yes") {
+                true
+            } else if input.trim().is_empty() {
+                default
+            } else {
+                false
+            }
+        }
+        Err(_) => {
+            println!(" -> Error reading input");
+            false
+        }
     }
 }
 


### PR DESCRIPTION
- Add proper EOF detection in ask() function
- Print " -> EOF" message when EOF is received
- Treat EOF as negative response
- Handle input read errors explicitly

closes #1190

![image](https://github.com/user-attachments/assets/7fa0637a-76c0-48aa-a434-0981e6618f3d)
![image](https://github.com/user-attachments/assets/780728c5-84ee-4908-b171-0bc94fd4806e)
