### PR TITLE
add PostBuildCommand

### DIFF
--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -366,6 +366,12 @@ impl Config {
             }
             Arg::Long("nosign") => self.sign = Sign::No,
             Arg::Long("nosigndb") => self.sign_db = Sign::No,
+            Arg::Long("post-build-command") => match value {
+                Ok(v) => {
+                    self.post_build_command = Some(v.to_string());
+                }
+                Err(_) => bail!(tr!("argument --post-build-command requires a value")),
+            },
             Arg::Long(a) if !arg.is_pacman_arg() && !arg.is_pacman_global() => {
                 bail!(tr!("unknown option --{}", a))
             }
@@ -448,6 +454,7 @@ fn takes_value(arg: Arg) -> TakesValue {
         Arg::Long("sign") => TakesValue::Optional,
         Arg::Long("signdb") => TakesValue::Optional,
         Arg::Long("mode") => TakesValue::Required,
+        Arg::Long("post-build-command") => TakesValue::Required,
         _ => TakesValue::No,
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -471,6 +471,7 @@ pub struct Config {
     pub sign_db: Sign,
 
     pub pre_build_command: Option<String>,
+    pub post_build_command: Option<String>,
 
     #[default = "makepkg"]
     pub makepkg_bin: String,
@@ -1023,6 +1024,7 @@ then initialise it with:
             "FileManagerFlags" => self.fm_flags.extend(split),
             "ChrootFlags" => self.chroot_flags.extend(split),
             "PreBuildCommand" => self.pre_build_command = Some(value),
+            "PostBuildCommand" => self.post_build_command = Some(value),
             _ => eprintln!(
                 "{}",
                 tr!("error: unknown option '{}' in section [bin]", key)

--- a/src/install.rs
+++ b/src/install.rs
@@ -607,6 +607,9 @@ impl Installer {
 
         self.add_pkg(config, base, repo, &pkgdests, &debug_paths)?;
         self.queue_install(base, &pkgdests, &debug_paths);
+
+        post_build_command(config, dir, base.package_base(), &version)?;
+
         Ok((pkgdests, version))
     }
 
@@ -1260,7 +1263,6 @@ fn print_warnings(config: &Config, cache: &Cache, actions: Option<&Actions>) {
     if !config.mode.aur() && !config.mode.pkgbuild() {
         return;
     }
-
     if config.args.has_arg("u", "sysupgrade") && config.mode.aur() {
         let (_, mut pkgs) = repo_aur_pkgs(config);
         pkgs.retain(|pkg| config.pkgbuild_repos.pkg(config, pkg.name()).is_none());
@@ -1547,6 +1549,19 @@ fn set_install_reason<S: AsRef<str>>(config: &Config, reason: &str, pkgs: &[S]) 
 
 fn pre_build_command(config: &Config, dir: &Path, base: &str, version: &str) -> Result<()> {
     if let Some(ref pb_cmd) = config.pre_build_command {
+        let mut cmd = Command::new("sh");
+        cmd.env("PKGBASE", base)
+            .env("VERSION", version)
+            .current_dir(dir)
+            .arg("-c")
+            .arg(pb_cmd);
+        exec::command(&mut cmd)?;
+    }
+    Ok(())
+}
+
+fn post_build_command(config: &Config, dir: &Path, base: &str, version: &str) -> Result<()> {
+    if let Some(ref pb_cmd) = config.post_build_command {
         let mut cmd = Command::new("sh");
         cmd.env("PKGBASE", base)
             .env("VERSION", version)


### PR DESCRIPTION
I have implemented the post-build command feature. Here's what I did:

1. Added post-build command parsing in `command_line.rs`:
   - Added handling for the `--post-build-command` argument
   - The argument requires a value which will be stored in `config.post_build_command`

2. Created a `post_build_command` function in `install.rs`:
   - Similar to `pre_build_command`, it executes a shell command after successful package build
   - The command has access to `PKGBASE` and `VERSION` environment variables
   - The command runs in the package build directory

3. Added post-build command execution in `install.rs`:
   - Called `post_build_command` after a successful package build
   - Only executes if a post-build command is configured

4. Added post-build command config in `config.rs`:
   - Added `PostBuildCommand` option to the config file parser
   - The command can be specified in the config file under the `[bin]` section

Users can specify a post-build command in these ways:

1. Via command line: `paru --post-build-command "your-command"`
2. Via config file: 

```ini
[bin]
PostBuildCommand = your-command
```

The command will receive:

- Current working directory set to the package build directory
- `PKGBASE`: The base package name
- `VERSION`: The package version

---

Tested with 
`cargo run -- -S vim-git --post-build-command "/tmp/code/paru/test.sh"`
and 
`paru.conf`
```
#
# Binary OPTIONS
#
[bin]
PostBuildCommand = "/tmp/code/paru/test.sh"
```

closes #1300