### PR TITLE
clean: handle subdirectories in pacman cache

### DIFF
--- a/src/clean.rs
+++ b/src/clean.rs
@@ -18,6 +18,23 @@ use tr::tr;
 
 pub fn clean(config: &Config) -> Result<()> {
     if config.mode.repo() {
+        if let Some(pkg_cache) = config.pacman.cache_dir.first() {
+            let pkg_cache = Path::new(pkg_cache);
+            if pkg_cache.exists() {
+                for entry in read_dir(pkg_cache)? {
+                    let entry = entry?;
+                    let path = entry.path();
+                    if path.is_dir() {
+                        let mut cmd = Command::new(&config.sudo_bin);
+                        cmd.args(&config.sudo_flags)
+                            .arg("rm")
+                            .arg("-rf")
+                            .arg(&path);
+                        exec::command(&mut cmd)?;
+                    }
+                }
+            }
+        }
         exec::pacman(config, &config.args)?;
     }
 


### PR DESCRIPTION
When running paru -Scc, ensure subdirectories in the pacman package cache are properly removed using sudo. Use the cache directory from pacman's configuration instead of hard-coding the path to respect user settings.


![image](https://github.com/user-attachments/assets/3c8e6383-f853-476b-af09-8c7a8ce7cf5e)

closes #1302 (further discussion there)