### PR TITLE
update MSRV to 1.80 due to LazyLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/paru"
 license = "GPL-3.0"
 keywords = ["archlinux", "arch", "alpm", "pacman", "aur"]
 include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md", "help"]
-rust-version = "1.78"
+rust-version = "1.80"
 
 
 [dependencies]


### PR DESCRIPTION
https://doc.rust-lang.org/std/sync/struct.LazyLock.html
```
warning: current MSRV (Minimum Supported Rust Version) is `1.78.0` but this item is stable since `1.80.0`
  --> src/exec.rs:28:52
   |
28 | static CAUGHT_SIGNAL: LazyLock<Arc<AtomicUsize>> = LazyLock::new(|| {
   |                                                    ^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incompatible_msrv
   ```
   
   sorry already need to update that