### PR TITLE
Resolve versions when looking for unused packages 

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1,19 +1,21 @@
+mod unneeded_pkgs;
+
 use crate::config::{Config, LocalRepos};
 use crate::repo;
 
-use std::cell::Cell;
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::{stdin, stdout, BufRead, Write};
 use std::ops::Range;
 use std::os::fd::{AsFd, AsRawFd};
 
-use alpm::{Package, PackageReason};
+use alpm::Package;
 use alpm_utils::{AsTarg, DbListExt, Targ};
 use anyhow::Result;
 use nix::libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 use nix::unistd::dup2;
 use tr::tr;
+
+pub use unneeded_pkgs::unneeded_pkgs;
 
 #[derive(Debug)]
 pub struct NumberMenu<'a> {
@@ -162,94 +164,6 @@ pub fn input(config: &Config, question: &str) -> String {
     let _ = stdin.read_line(&mut input);
     input
 }
-
-#[derive(Hash, PartialEq, Eq, SmartDefault, Copy, Clone)]
-enum State {
-    #[default]
-    Remove,
-    CheckDeps,
-    Keep,
-}
-
-pub fn unneeded_pkgs(config: &Config, keep_make: bool, keep_optional: bool) -> Vec<&str> {
-    let mut states = HashMap::new();
-    let mut remove = Vec::new();
-    let mut providers = HashMap::<_, Vec<_>>::new();
-    let db = config.alpm.localdb();
-
-    for pkg in db.pkgs() {
-        providers
-            .entry(pkg.name().to_string())
-            .or_default()
-            .push(pkg.name());
-        for dep in pkg.provides() {
-            providers
-                .entry(dep.name().to_string())
-                .or_default()
-                .push(pkg.name())
-        }
-
-        if pkg.reason() == PackageReason::Explicit {
-            states.insert(pkg.name(), Cell::new(State::CheckDeps));
-        } else {
-            states.insert(pkg.name(), Cell::new(State::Remove));
-        }
-    }
-
-    let mut again = true;
-
-    while again {
-        again = false;
-
-        let mut check_deps = |deps: alpm::AlpmList<&alpm::Dep>| {
-            for dep in deps {
-                if let Some(deps) = providers.get(dep.name()) {
-                    for dep in deps {
-                        let state = states.get(dep).unwrap();
-
-                        if state.get() != State::Keep {
-                            state.set(State::CheckDeps);
-                            again = true;
-                        }
-                    }
-                }
-            }
-        };
-
-        for (&pkg, state) in &states {
-            if state.get() != State::CheckDeps {
-                continue;
-            }
-
-            if let Ok(pkg) = db.pkg(pkg) {
-                state.set(State::Keep);
-                check_deps(pkg.depends());
-
-                if keep_optional {
-                    check_deps(pkg.optdepends());
-                }
-
-                if keep_make {
-                    continue;
-                }
-
-                if config.alpm.syncdbs().pkg(pkg.name()).is_err() {
-                    check_deps(pkg.makedepends());
-                    check_deps(pkg.checkdepends());
-                }
-            }
-        }
-    }
-
-    for pkg in db.pkgs() {
-        if states.get(pkg.name()).unwrap().get() == State::Remove {
-            remove.push(pkg.name());
-        }
-    }
-
-    remove
-}
-
 impl<'a> NumberMenu<'a> {
     pub fn new(input: &'a str) -> Self {
         let mut include_range = Vec::new();

--- a/src/util/unneeded_pkgs.rs
+++ b/src/util/unneeded_pkgs.rs
@@ -1,147 +1,211 @@
 use std::{cell::Cell, cmp::Ordering, collections::HashMap};
 
-use alpm::{DepMod, PackageReason, Ver};
+use alpm::{AlpmList, Dep, DepMod, PackageReason, Ver};
 use alpm_utils::DbListExt;
 
 use crate::config::Config;
 
+type PkgName<'a> = &'a str;
+
+/// Removal state of a package
 #[derive(Hash, PartialEq, Eq, Default, Copy, Clone)]
 enum State {
+    /// This package should be kept (probably explicitely installed or used by an explicitely installed package)
+    Keep { deps: DepState },
+
+    /// This package should be removed
     #[default]
     Remove,
-    /// The same as keep but whose dependencies need to be checked first
-    CheckDeps,
-    Keep,
+}
+
+/// Traversal state of a package's dependencies.
+#[derive(Hash, PartialEq, Eq, Copy, Clone)]
+enum DepState {
+    /// All dependencies have already been traversed and marked [`State::Keep`]
+    AlreadyMarked,
+
+    /// The package has already been marked [`State::Keep`] but its dependencies haven't been marked yet
+    NotMarkedYet,
 }
 
 // A provider of a dependency
 #[derive(Debug)]
 struct Provider<'a> {
     // Name of the package that provides some dependency
-    name: &'a str,
+    pkg_name: PkgName<'a>,
 
     // Version of the dependency that package provides
     ver: Option<&'a Ver>,
 }
 
-pub fn unneeded_pkgs(config: &Config, keep_make: bool, keep_optional: bool) -> Vec<&str> {
-    let mut states = HashMap::new();
-    let mut remove = Vec::new();
-    let mut providers: HashMap<&str, Vec<Provider>> = HashMap::new();
+pub fn unneeded_pkgs(config: &Config, keep_make: bool, keep_optional: bool) -> Vec<PkgName<'_>> {
+    // Removal state of each package on the system
+    let mut states: HashMap<PkgName, Cell<State>> = HashMap::new();
+
+    // A list of every provided dependency.
+    // Maps from provided dependency name -> provided dependency version and the name of the package that provides it.
+    let mut providers: HashMap<PkgName, Vec<Provider>> = HashMap::new();
     let db = config.alpm.localdb();
 
-    // iterate over all packages
+    // Iterate over all packages and populate `states` and `providers`
     for pkg in db.pkgs() {
-        // add self as a provider of self
+        // Add pkg as a provider of pkg
         let provider = Provider {
-            name: pkg.name(),
+            pkg_name: pkg.name(),
             ver: Some(pkg.version()),
         };
         providers.entry(pkg.name()).or_default().push(provider);
 
-        // add self as a provider of all packages that it "provides"
+        // Add pkg as a provider of all dependencies that pkg provides
         for dep in pkg.provides() {
             let provider = Provider {
-                name: pkg.name(),
+                pkg_name: pkg.name(),
                 ver: dep.version(),
             };
 
             providers.entry(dep.name()).or_default().push(provider);
         }
 
-        // mark the package to be removed if not explicitely installed
+        // By default, mark every explicitely installed package to be kept, and every dependency to be removed
         if pkg.reason() == PackageReason::Explicit {
-            states.insert(pkg.name(), Cell::new(State::CheckDeps));
+            states.insert(
+                pkg.name(),
+                Cell::new(State::Keep {
+                    deps: DepState::NotMarkedYet,
+                }),
+            );
         } else {
             states.insert(pkg.name(), Cell::new(State::Remove));
         }
     }
 
-    // now
-    // states contains names of pkgs mapped to -> checkdeps if explicit, remove otherwise
-    // providers contains a list of all package providers
+    // Go through all packages that are marked to be kept and mark their dependencies as also needed to be kept
+    let mut every_dependency_checked = false;
+    while !every_dependency_checked {
+        // assume we checked every dependency
+        // this is set to false if we found some that haven't been checked yet
+        every_dependency_checked = true;
 
-    let mut again = true;
-    while again {
-        again = false;
-
-        // marks all providers of the dependency this package requires as "CheckDeps"
-        let mut check_deps = |deps: alpm::AlpmList<&alpm::Dep>| {
-            for dep in deps {
-                // get all providers of the dependency dep
-                for provider in providers
-                    .get(dep.name())
-                    .into_iter()
-                    .flatten()
-                    .filter(|provider| {
-                        let Some(required_version) = dep.version() else {
-                            // pass through all providers if the package doesn't depend on a particular version
-                            return true;
-                        };
-
-                        let Some(provided_version) = provider.ver else {
-                            // the provider doesn't specify what version it provides but we depend on a particular version
-                            return false;
-                        };
-
-                        let ver_cmp = provided_version.vercmp(required_version);
-                        let ver_requirement = dep.depmod();
-                        match (ver_cmp, ver_requirement) {
-                            // Note: I don't believe this should ever be hit because a version requirement ~does~ exist
-                            // (because dep.version() is Some)
-                            (_, DepMod::Any) => true,
-                            (Ordering::Less, DepMod::Lt | DepMod::Le) => true,
-                            (Ordering::Equal, DepMod::Eq | DepMod::Le | DepMod::Ge) => true,
-                            (Ordering::Greater, DepMod::Gt | DepMod::Ge) => true,
-                            _ => false,
-                        }
-                    })
-                {
-                    let state = states.get(provider.name).unwrap();
-
-                    // if the dependency isn't marked to keep (probably marked to remove?), then mark to check its dependencies instead
-                    // this means this package is needed
-                    if state.get() != State::Keep {
-                        state.set(State::CheckDeps);
-                        again = true;
-                    }
+        // Iterate over all packages that need their dependencies to be marked to keep, and mark them to keep.
+        // At the start these are only those that have been explicitely installed but later can also be the dependencies of them and their dependencies.
+        // This also means that packages that were installed as dependencies but then never reaced through .depends() and friends are left to be removed
+        for (&pkg, state) in states.iter().filter(|(_, state)| {
+            state.get()
+                == State::Keep {
+                    deps: DepState::NotMarkedYet,
                 }
-            }
-        };
+        }) {
+            let pkg = db.pkg(pkg).unwrap();
 
-        // iterate over all packages that need their dependencies to be checked, and mark them to keep
-        // at the start these are only those that have been explicitely installed but later can also be the dependencies of them and their dependencies
-        // this also means that packages that were installed as dependencies but then never reaced through .depends() and friends are left to be removed
-        for (&pkg, state) in &states {
-            if state.get() != State::CheckDeps {
+            state.set(State::Keep {
+                deps: DepState::AlreadyMarked,
+            });
+
+            mark_deps_as_kept(
+                pkg.depends(),
+                &providers,
+                &states,
+                &mut every_dependency_checked,
+            );
+
+            if keep_optional {
+                mark_deps_as_kept(
+                    pkg.optdepends(),
+                    &providers,
+                    &states,
+                    &mut every_dependency_checked,
+                );
+            }
+
+            if keep_make {
                 continue;
             }
 
-            if let Ok(pkg) = db.pkg(pkg) {
-                state.set(State::Keep);
-                check_deps(pkg.depends());
-
-                if keep_optional {
-                    check_deps(pkg.optdepends());
-                }
-
-                if keep_make {
-                    continue;
-                }
-
-                if config.alpm.syncdbs().pkg(pkg.name()).is_err() {
-                    check_deps(pkg.makedepends());
-                    check_deps(pkg.checkdepends());
-                }
+            if config.alpm.syncdbs().pkg(pkg.name()).is_err() {
+                mark_deps_as_kept(
+                    pkg.makedepends(),
+                    &providers,
+                    &states,
+                    &mut every_dependency_checked,
+                );
+                mark_deps_as_kept(
+                    pkg.checkdepends(),
+                    &providers,
+                    &states,
+                    &mut every_dependency_checked,
+                );
             }
         }
     }
 
-    for pkg in db.pkgs() {
-        if states.get(pkg.name()).unwrap().get() == State::Remove {
-            remove.push(pkg.name());
+    states
+        .into_iter()
+        .filter_map(|(pkg, state)| {
+            if state.get() == State::Remove {
+                Some(pkg)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Marks all dependency providers that satisfy the dependencies of this package requires with [`State::Keep`]
+fn mark_deps_as_kept(
+    dependencies: AlpmList<&Dep>,
+    providers: &HashMap<PkgName, Vec<Provider>>,
+    states: &HashMap<PkgName, Cell<State>>,
+    every_dependency_marked: &mut bool,
+) {
+    for dep in dependencies {
+        // mark all providers that satisfy the dependency as to be kept
+        for provider in providers
+            .get(dep.name())
+            .into_iter()
+            .flatten()
+            .filter(|provider| provider_satisfies_dependency(dep, provider))
+        {
+            let state = states
+                .get(provider.pkg_name)
+                .expect("state should have all packages");
+
+            // if the dependency hasn't already been recursively marked as to kept, mark it, and edit the marking loop to go through this package's dependencies, too.
+            if state.get()
+                != (State::Keep {
+                    deps: DepState::AlreadyMarked,
+                })
+            {
+                state.set(State::Keep {
+                    deps: DepState::NotMarkedYet,
+                });
+                *every_dependency_marked = false;
+            }
         }
     }
+}
 
-    remove
+/// Checks if the provider of the dependency satisfies its version requirements
+fn provider_satisfies_dependency(dep: &Dep, provider: &Provider) -> bool {
+    let Some(required_version) = dep.version() else {
+        // dependency doesn't depend on any particular version
+        return true;
+    };
+
+    let Some(provided_version) = provider.ver else {
+        // provider doesn't specify what version it provides but we depend on a particular version
+        return false;
+    };
+
+    let ver_cmp = provided_version.vercmp(required_version);
+    let ver_requirement = dep.depmod();
+
+    match (ver_cmp, ver_requirement) {
+        // Note: I don't believe this should ever be hit because a version requirement ~does~ exist
+        // (because dep.version() is Some)
+        (_, DepMod::Any) => true,
+        (Ordering::Less, DepMod::Lt | DepMod::Le) => true,
+        (Ordering::Equal, DepMod::Eq | DepMod::Le | DepMod::Ge) => true,
+        (Ordering::Greater, DepMod::Gt | DepMod::Ge) => true,
+        _ => false,
+    }
 }

--- a/src/util/unneeded_pkgs.rs
+++ b/src/util/unneeded_pkgs.rs
@@ -1,0 +1,147 @@
+use std::{cell::Cell, cmp::Ordering, collections::HashMap};
+
+use alpm::{DepMod, PackageReason, Ver};
+use alpm_utils::DbListExt;
+
+use crate::config::Config;
+
+#[derive(Hash, PartialEq, Eq, Default, Copy, Clone)]
+enum State {
+    #[default]
+    Remove,
+    /// The same as keep but whose dependencies need to be checked first
+    CheckDeps,
+    Keep,
+}
+
+// A provider of a dependency
+#[derive(Debug)]
+struct Provider<'a> {
+    // Name of the package that provides some dependency
+    name: &'a str,
+
+    // Version of the dependency that package provides
+    ver: Option<&'a Ver>,
+}
+
+pub fn unneeded_pkgs(config: &Config, keep_make: bool, keep_optional: bool) -> Vec<&str> {
+    let mut states = HashMap::new();
+    let mut remove = Vec::new();
+    let mut providers: HashMap<&str, Vec<Provider>> = HashMap::new();
+    let db = config.alpm.localdb();
+
+    // iterate over all packages
+    for pkg in db.pkgs() {
+        // add self as a provider of self
+        let provider = Provider {
+            name: pkg.name(),
+            ver: Some(pkg.version()),
+        };
+        providers.entry(pkg.name()).or_default().push(provider);
+
+        // add self as a provider of all packages that it "provides"
+        for dep in pkg.provides() {
+            let provider = Provider {
+                name: pkg.name(),
+                ver: dep.version(),
+            };
+
+            providers.entry(dep.name()).or_default().push(provider);
+        }
+
+        // mark the package to be removed if not explicitely installed
+        if pkg.reason() == PackageReason::Explicit {
+            states.insert(pkg.name(), Cell::new(State::CheckDeps));
+        } else {
+            states.insert(pkg.name(), Cell::new(State::Remove));
+        }
+    }
+
+    // now
+    // states contains names of pkgs mapped to -> checkdeps if explicit, remove otherwise
+    // providers contains a list of all package providers
+
+    let mut again = true;
+    while again {
+        again = false;
+
+        // marks all providers of the dependency this package requires as "CheckDeps"
+        let mut check_deps = |deps: alpm::AlpmList<&alpm::Dep>| {
+            for dep in deps {
+                // get all providers of the dependency dep
+                for provider in providers
+                    .get(dep.name())
+                    .into_iter()
+                    .flatten()
+                    .filter(|provider| {
+                        let Some(required_version) = dep.version() else {
+                            // pass through all providers if the package doesn't depend on a particular version
+                            return true;
+                        };
+
+                        let Some(provided_version) = provider.ver else {
+                            // the provider doesn't specify what version it provides but we depend on a particular version
+                            return false;
+                        };
+
+                        let ver_cmp = provided_version.vercmp(required_version);
+                        let ver_requirement = dep.depmod();
+                        match (ver_cmp, ver_requirement) {
+                            // Note: I don't believe this should ever be hit because a version requirement ~does~ exist
+                            // (because dep.version() is Some)
+                            (_, DepMod::Any) => true,
+                            (Ordering::Less, DepMod::Lt | DepMod::Le) => true,
+                            (Ordering::Equal, DepMod::Eq | DepMod::Le | DepMod::Ge) => true,
+                            (Ordering::Greater, DepMod::Gt | DepMod::Ge) => true,
+                            _ => false,
+                        }
+                    })
+                {
+                    let state = states.get(provider.name).unwrap();
+
+                    // if the dependency isn't marked to keep (probably marked to remove?), then mark to check its dependencies instead
+                    // this means this package is needed
+                    if state.get() != State::Keep {
+                        state.set(State::CheckDeps);
+                        again = true;
+                    }
+                }
+            }
+        };
+
+        // iterate over all packages that need their dependencies to be checked, and mark them to keep
+        // at the start these are only those that have been explicitely installed but later can also be the dependencies of them and their dependencies
+        // this also means that packages that were installed as dependencies but then never reaced through .depends() and friends are left to be removed
+        for (&pkg, state) in &states {
+            if state.get() != State::CheckDeps {
+                continue;
+            }
+
+            if let Ok(pkg) = db.pkg(pkg) {
+                state.set(State::Keep);
+                check_deps(pkg.depends());
+
+                if keep_optional {
+                    check_deps(pkg.optdepends());
+                }
+
+                if keep_make {
+                    continue;
+                }
+
+                if config.alpm.syncdbs().pkg(pkg.name()).is_err() {
+                    check_deps(pkg.makedepends());
+                    check_deps(pkg.checkdepends());
+                }
+            }
+        }
+    }
+
+    for pkg in db.pkgs() {
+        if states.get(pkg.name()).unwrap().get() == State::Remove {
+            remove.push(pkg.name());
+        }
+    }
+
+    remove
+}


### PR DESCRIPTION
This PR fixes #1335 by keeping track of versions of provided dependencies and keeping only those providers that actually satisfy the package and version dependencies.

I've also reworked and split the functions into several smaller ones and documented the control flow of the main function as much as possible (it was very difficult to understand at first what the original function was doing, so I tried my best to make it as easily understandable for future maintainers as I could).

P.S. I'm very new to alpm, so I couldn't find an alpm function that checks if a package satisfies a dependency. If one exists, we can use it instead.