### PR TITLE
General iterator-related refactor

### DIFF
--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -122,13 +122,13 @@ impl Chroot {
         self.run(&["pacman", "-Syu", "--noconfirm"])
     }
 
-    pub fn build<S: AsRef<OsStr>>(
+    pub fn build<'e, S: AsRef<OsStr>>(
         &self,
         pkgbuild: &Path,
         pkgs: &[&str],
-        chroot_flags: &[S],
+        chroot_flags: impl IntoIterator<Item = S>,
         flags: &[&str],
-        env: &[(String, String)],
+        env: impl IntoIterator<Item = (&'e str, &'e str)>,
     ) -> Result<()> {
         let mut cmd = Command::new("makechrootpkg");
 

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -17,7 +17,7 @@ enum Arg<'a> {
     Long(&'a str),
 }
 
-impl<'a> fmt::Display for Arg<'a> {
+impl fmt::Display for Arg<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Arg::Short(c) => write!(f, "-{}", c),
@@ -26,7 +26,7 @@ impl<'a> fmt::Display for Arg<'a> {
     }
 }
 
-impl<'a> Arg<'a> {
+impl Arg<'_> {
     fn arg(self) -> String {
         match self {
             Arg::Long(arg) => arg.to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,9 +167,7 @@ pub trait ConfigEnum: Sized + PartialEq + Copy + Clone + fmt::Debug + 'static {
             .find(|(name, _)| name == &value)
             .map(|(_, res)| *res);
 
-        if let Some(val) = val {
-            Ok(val)
-        } else {
+        let Some(val) = val else {
             let okvalues = Self::VALUE_LOOKUP
                 .iter()
                 .map(|v| v.0)
@@ -181,7 +179,8 @@ pub trait ConfigEnum: Sized + PartialEq + Copy + Clone + fmt::Debug + 'static {
                 key = key,
                 exp = okvalues
             ))
-        }
+        };
+        Ok(val)
     }
 }
 

--- a/src/devel.rs
+++ b/src/devel.rs
@@ -112,7 +112,7 @@ pub async fn gendb(config: &mut Config) -> Result<()> {
     let bold = config.color.bold;
 
     let db = config.alpm.localdb();
-    let pkgs = db.pkgs().iter().map(|p| p.name()).collect::<Vec<_>>();
+    let pkgs: Vec<_> = db.pkgs().iter().map(|p| p.name()).collect();
     let ignore = &config.ignore;
 
     let (_, mut aur) = split_repo_aur_pkgs(config, &pkgs);
@@ -193,7 +193,7 @@ pub async fn gendb(config: &mut Config) -> Result<()> {
         }
     }
 
-    let bases = bases.bases.into_iter().map(Base::Aur).collect::<Vec<_>>();
+    let bases: Vec<_> = bases.bases.into_iter().map(Base::Aur).collect();
 
     println!(
         "{} {}",
@@ -378,16 +378,13 @@ pub async fn possible_devel_updates(config: &Config) -> Result<Vec<String>> {
 
     let updates = join_all(futures).await;
 
-    let mut updates = updates
+    let updates = updates
         .into_iter()
         .flatten()
         .map(|s| s.to_string())
-        .collect::<Vec<_>>();
+        .collect::<std::collections::BTreeSet<_>>();
 
-    updates.sort_unstable();
-    updates.dedup();
-
-    Ok(updates)
+    Ok(updates.into_iter().collect())
 }
 
 pub async fn filter_devel_updates(
@@ -421,10 +418,10 @@ pub async fn filter_devel_updates(
     }
 
     config.raur.cache_info(cache, &aur).await?;
-    let aur = aur
+    let aur: Vec<_> = aur
         .iter()
         .map(|u| pkgbases.remove(u.as_str()).unwrap())
-        .collect::<Vec<_>>();
+        .collect();
 
     let mut updates = Vec::new();
 
@@ -447,10 +444,10 @@ pub async fn filter_devel_updates(
     Ok(updates)
 }
 
-pub async fn pkg_has_update<'pkg, 'info, 'cfg>(
-    config: &'cfg Config,
+pub async fn pkg_has_update<'pkg>(
+    config: &Config,
     pkg: &'pkg str,
-    info: &'info HashSet<RepoInfo>,
+    info: &HashSet<RepoInfo>,
 ) -> Option<&'pkg str> {
     if info.is_empty() {
         return None;

--- a/src/download.rs
+++ b/src/download.rs
@@ -87,7 +87,7 @@ pub struct Warnings<'a> {
     pub orphans: Vec<&'a str>,
 }
 
-impl<'a> Warnings<'a> {
+impl Warnings<'_> {
     pub fn missing(&self, color: Colors, cols: Option<usize>) -> &Self {
         if !self.missing.is_empty() {
             let b = color.bold;
@@ -175,11 +175,7 @@ pub async fn cache_info_with_warnings<'a, S: AsRef<str> + Send + Sync>(
 }
 
 pub async fn getpkgbuilds(config: &mut Config) -> Result<i32> {
-    let pkgs = config
-        .targets
-        .iter()
-        .map(|t| t.as_str())
-        .collect::<Vec<_>>();
+    let pkgs: Vec<_> = config.targets.iter().map(|t| t.as_str()).collect();
 
     let (repo, aur) = split_repo_aur_pkgbuilds(config, &pkgs);
     let mut ret = 0;
@@ -189,7 +185,7 @@ pub async fn getpkgbuilds(config: &mut Config) -> Result<i32> {
     }
 
     if !aur.is_empty() {
-        let aur = aur.iter().map(|t| t.pkg).collect::<Vec<_>>();
+        let aur: Vec<_> = aur.iter().map(|t| t.pkg).collect();
         let action = config.color.action;
         let bold = config.color.bold;
         println!(
@@ -263,11 +259,7 @@ pub fn print_download(_config: &Config, n: usize, total: usize, pkg: &str) {
 }
 
 async fn aur_pkgbuilds(config: &Config, bases: &Bases) -> Result<()> {
-    let download = bases
-        .bases
-        .iter()
-        .map(|p| p.package_base())
-        .collect::<Vec<_>>();
+    let download: Vec<_> = bases.bases.iter().map(|p| p.package_base()).collect();
 
     let cols = config.cols.unwrap_or(0);
 
@@ -337,11 +329,7 @@ pub async fn new_aur_pkgbuilds(
         return Ok(());
     }
 
-    let all_pkgs = bases
-        .bases
-        .iter()
-        .map(|b| b.package_base())
-        .collect::<Vec<_>>();
+    let all_pkgs: Vec<_> = bases.bases.iter().map(|b| b.package_base()).collect();
 
     if config.redownload == YesNoAll::All {
         aur_pkgbuilds(config, bases).await?;
@@ -418,10 +406,10 @@ pub async fn show_comments(config: &mut Config) -> Result<i32> {
             .select(&comments_selector)
             .map(|node| node.text().collect::<String>());
 
-        let iter = titles.zip(comments).collect::<Vec<_>>();
+        let iter: Vec<_> = titles.zip(comments).collect();
 
         if config.sort_mode == SortMode::TopDown {
-            for (title, comment) in iter.into_iter() {
+            for (title, comment) in iter {
                 print_indent(c.bold, 0, 0, config.cols, " ", title.split_whitespace());
 
                 for line in comment.trim().split('\n') {
@@ -544,7 +532,7 @@ pub async fn show_pkgbuilds(config: &mut Config) -> Result<i32> {
     }
 
     if !aur.is_empty() {
-        let aur = aur.iter().map(|t| t.pkg).collect::<Vec<_>>();
+        let aur: Vec<_> = aur.iter().map(|t| t.pkg).collect();
 
         let warnings = cache_info_with_warnings(
             &config.raur,

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -49,13 +49,13 @@ fn word_len(s: &str) -> usize {
     len
 }
 
-pub fn print_indent<S: AsRef<str>>(
+pub fn print_indent(
     color: Style,
     start: usize,
     indent: usize,
     cols: Option<usize>,
     sep: &str,
-    value: impl IntoIterator<Item = S>,
+    value: impl IntoIterator<Item = impl AsRef<str>>,
 ) {
     let v = value.into_iter();
 
@@ -165,7 +165,7 @@ fn to_install(config: &Config, actions: &Actions, devel: &HashSet<String>) -> To
     let c = config.color;
     let dash = c.install_version.paint("-");
 
-    let install = actions
+    let install: Vec<_> = actions
         .install
         .iter()
         .filter(|p| !p.make)
@@ -177,8 +177,8 @@ fn to_install(config: &Config, actions: &Actions, devel: &HashSet<String>) -> To
                 c.install_version.paint(p.pkg.version().to_string())
             )
         })
-        .collect::<Vec<_>>();
-    let make_install = actions
+        .collect();
+    let make_install: Vec<_> = actions
         .install
         .iter()
         .filter(|p| p.make)
@@ -190,7 +190,7 @@ fn to_install(config: &Config, actions: &Actions, devel: &HashSet<String>) -> To
                 c.install_version.paint(p.pkg.version().to_string())
             )
         })
-        .collect::<Vec<_>>();
+        .collect();
 
     let mut build = actions.build.clone();
     for base in &mut build {
@@ -203,7 +203,7 @@ fn to_install(config: &Config, actions: &Actions, devel: &HashSet<String>) -> To
     let build = build
         .iter()
         .map(|p| base_string(config, p, devel))
-        .collect::<Vec<_>>();
+        .collect();
 
     let mut make_build = actions.build.clone();
     for base in &mut make_build {
@@ -216,7 +216,7 @@ fn to_install(config: &Config, actions: &Actions, devel: &HashSet<String>) -> To
     let make_build = make_build
         .iter()
         .map(|p| base_string(config, p, devel))
-        .collect::<Vec<_>>();
+        .collect();
 
     ToInstall {
         install,

--- a/src/info.rs
+++ b/src/info.rs
@@ -17,7 +17,7 @@ use unicode_width::UnicodeWidthStr;
 
 pub async fn info(conf: &mut Config, verbose: bool) -> Result<i32, Error> {
     let targets = conf.targets.clone();
-    let targets = targets.iter().map(Targ::from).collect::<Vec<_>>();
+    let targets: Vec<_> = targets.iter().map(Targ::from).collect();
 
     let (repo, aur) = split_repo_aur_info(conf, &targets)?;
     let mut ret = 0;
@@ -44,7 +44,7 @@ pub async fn info(conf: &mut Config, verbose: bool) -> Result<i32, Error> {
 
     let aur = if !aur.is_empty() {
         let color = conf.color;
-        let aur = aur.iter().map(|t| t.pkg).collect::<Vec<_>>();
+        let aur: Vec<_> = aur.iter().map(|t| t.pkg).collect();
         let warnings =
             cache_info_with_warnings(&conf.raur, &mut conf.cache, &aur, &[], &GlobSet::empty())
                 .await?;
@@ -62,7 +62,7 @@ pub async fn info(conf: &mut Config, verbose: bool) -> Result<i32, Error> {
     };
 
     if !repo.is_empty() {
-        let targets = repo.into_iter().map(|t| t.to_string()).collect::<Vec<_>>();
+        let targets: Vec<_> = repo.into_iter().map(|t| t.to_string()).collect();
         let mut args = conf.pacman_args();
         args.targets.clear();
         args.targets(targets.iter().map(|t| t.as_str()));

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -53,7 +53,7 @@ pub fn check_pgp_keys(
             c.bold.paint(tr!("keys need to be imported:"))
         );
         for (key, base) in &import {
-            let base = base.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+            let base: Vec<_> = base.iter().map(|s| s.to_string()).collect();
             printtr!(
                 "     {key} wanted by: {base}",
                 key = c.bold.paint(*key),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::process::exit;
 
 #[tokio::main]
 async fn main() {
-    let args = std::env::args().skip(1).collect::<Vec<_>>();
-    let ret = run(&args).await;
+    let args = std::env::args().skip(1);
+    let ret = run(args).await;
     exit(ret);
 }

--- a/src/pkgbuild.rs
+++ b/src/pkgbuild.rs
@@ -124,12 +124,15 @@ impl PkgbuildRepo {
         Ok(repo)
     }
 
-    pub fn from_pkgbuilds(config: &Config, dirs: &[PathBuf]) -> Result<PkgbuildRepo> {
+    pub fn from_pkgbuilds(
+        config: &Config,
+        dirs: impl IntoIterator<Item = impl AsRef<Path>>,
+    ) -> Result<PkgbuildRepo> {
         let mut pkgs = Vec::new();
         let mut repo = Self::from_cwd(config)?;
 
         for dir in dirs {
-            let dir = dir.canonicalize()?;
+            let dir = dir.as_ref().canonicalize()?;
             repo.print_generate_srcinfo(config, &dir.file_name().unwrap().to_string_lossy());
             let srcinfo = read_srcinfo_from_pkgbuild(config, &dir)?;
             pkgs.push(PkgbuildPkg {
@@ -331,7 +334,7 @@ impl PkgbuildRepos {
         let action = config.color.action;
         let bold = config.color.bold;
 
-        let repos = self
+        let repos: Vec<_> = self
             .repos
             .iter()
             .filter_map(|r| {
@@ -343,7 +346,7 @@ impl PkgbuildRepos {
                         name: n.to_string(),
                     })
             })
-            .collect::<Vec<_>>();
+            .collect();
 
         if repos.is_empty() {
             return Ok(());
@@ -381,7 +384,7 @@ impl PkgbuildRepos {
             println!();
         }
 
-        let review_repos = repos
+        let review_repos: Vec<_> = repos
             .iter()
             .filter(|r| {
                 !config
@@ -391,10 +394,10 @@ impl PkgbuildRepos {
                     .unwrap_or(false)
             })
             .map(|r| r.name.as_str())
-            .collect::<Vec<_>>();
+            .collect();
         review(config, &self.fetch, &review_repos)?;
 
-        let all_repos = repos.iter().map(|r| r.name.as_str()).collect::<Vec<_>>();
+        let all_repos: Vec<_> = repos.iter().map(|r| r.name.as_str()).collect();
         self.fetch.merge(&all_repos)?;
 
         self.repos.iter().for_each(|r| r.generate_srcinfos(config));

--- a/src/query.rs
+++ b/src/query.rs
@@ -22,7 +22,7 @@ pub async fn print_upgrade_list(config: &mut Config) -> Result<i32> {
     }
 
     let targets: Vec<_> = if config.targets.is_empty() {
-        db.pkgs().iter().map(|p| p.name()).collect::<Vec<_>>()
+        db.pkgs().iter().map(|p| p.name()).collect()
     } else {
         config.targets.iter().map(|s| s.as_str()).collect()
     };
@@ -57,7 +57,7 @@ pub async fn print_upgrade_list(config: &mut Config) -> Result<i32> {
         let output = exec::pacman_output(config, &args)?;
         let aur = String::from_utf8(output.stdout)?;
 
-        let mut aur = aur.trim().lines().collect::<Vec<_>>();
+        let mut aur: Vec<_> = aur.trim().lines().collect();
 
         if config.mode.pkgbuild() {
             aur.retain(|&target| {

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -16,12 +16,12 @@ pub fn remove(config: &mut Config) -> Result<i32> {
 
     let mut devel_info = load_devel_info(config)?.unwrap_or_default();
     let db = config.alpm.localdb();
-    let bases = config
+    let bases: Vec<_> = config
         .targets
         .iter()
         .filter_map(|pkg| db.pkg(pkg.as_str()).ok())
         .map(pkg_base_or_name)
-        .collect::<Vec<_>>();
+        .collect();
 
     let mut db_map: HashMap<String, Vec<String>> = HashMap::new();
     let (_, local_repos) = repo::repo_aur_dbs(config);

--- a/src/search.rs
+++ b/src/search.rs
@@ -27,11 +27,7 @@ pub async fn search(config: &Config) -> Result<i32> {
 
     let repo_pkgs = search_repos(config, &config.targets)?;
 
-    let targets = config
-        .targets
-        .iter()
-        .map(|t| t.to_lowercase())
-        .collect::<Vec<_>>();
+    let targets: Vec<_> = config.targets.iter().map(|t| t.to_lowercase()).collect();
 
     let custom_pkgs = search_pkgbuilds(config, &targets)?;
 
@@ -176,11 +172,11 @@ async fn search_aur_regex(config: &Config, targets: &[String]) -> Result<Vec<rau
 
     let regex = RegexSet::new(targets)?;
 
-    let pkgs = data
+    let pkgs: Vec<_> = data
         .lines()
         .skip(1)
         .filter(|pkg| regex.is_match(pkg))
-        .collect::<Vec<_>>();
+        .collect();
     ensure!(pkgs.len() < 2000, "too many packages");
     let pkgs = config.raur.info(&pkgs).await?;
     Ok(pkgs)
@@ -194,7 +190,7 @@ async fn search_aur(config: &Config, targets: &[String]) -> Result<Vec<raur::Pac
     let mut matches = if config.args.has_arg("x", "regex") {
         search_aur_regex(config, targets).await?
     } else {
-        let mut targets = targets.iter().map(|t| t.to_lowercase()).collect::<Vec<_>>();
+        let mut targets: Vec<_> = targets.iter().map(|t| t.to_lowercase()).collect();
         targets.sort_by_key(|t| t.len());
 
         let mut matches = Vec::new();
@@ -452,7 +448,7 @@ pub fn interactive_menu(
         return Ok(Vec::new());
     }
 
-    let indexes = all_pkgs
+    let indexes: Vec<_> = all_pkgs
         .iter()
         .enumerate()
         .filter_map(|(n, pkg)| {
@@ -468,9 +464,9 @@ pub fn interactive_menu(
                 None
             }
         })
-        .collect::<Vec<_>>();
+        .collect();
 
-    for (i, n) in indexes.iter().rev().enumerate() {
+    for (i, n) in indexes.into_iter().rev().enumerate() {
         let pkg = all_pkgs.remove(i + n);
         all_pkgs.insert(0, pkg);
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -68,11 +68,7 @@ pub async fn stats(config: &Config) -> Result<i32> {
     let c = config.color;
     let info = collect_info(config, 10).await?;
     let (repo, possible_aur) = repo_aur_pkgs(config);
-    let aur_packages = possible_aur
-        .iter()
-        .map(|pkg| pkg.name())
-        .map(|s| s.to_owned())
-        .collect::<Vec<_>>();
+    let aur_packages: Vec<_> = possible_aur.iter().map(|pkg| pkg.name()).collect();
 
     let warnings = cache_info_with_warnings(
         &config.raur,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -109,11 +109,11 @@ pub async fn list_aur(config: &Config) -> Result<()> {
     let stdout = std::io::stdout();
     let mut stdout = stdout.lock();
 
-    let mut lines = data
+    let mut lines: Vec<_> = data
         .split(|&c| c == b'\n')
         .skip(1)
         .filter(|l| !l.is_empty())
-        .collect::<Vec<_>>();
+        .collect();
 
     lines.sort_unstable();
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -394,8 +394,8 @@ pub fn split_repo_aur_pkgs<S: AsRef<str> + Clone>(config: &Config, pkgs: &[S]) -
 pub fn repo_aur_pkgs(config: &Config) -> (Vec<&alpm::Package>, Vec<&alpm::Package>) {
     if config.repos != LocalRepos::None {
         let (repo, aur) = repo::repo_aur_dbs(config);
-        let repo = repo.iter().flat_map(|db| db.pkgs()).collect::<Vec<_>>();
-        let aur = aur.iter().flat_map(|db| db.pkgs()).collect::<Vec<_>>();
+        let repo: Vec<_> = repo.iter().flat_map(|db| db.pkgs()).collect();
+        let aur: Vec<_> = aur.iter().flat_map(|db| db.pkgs()).collect();
         (repo, aur)
     } else {
         let (repo, aur) = config

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -172,12 +172,12 @@ async fn run(run_args: &[&str], repo: bool) -> Result<(TempDir, i32)> {
     if repo {
         let mut args = args.clone();
         args.push("-Ly");
-        let ret = paru::run(&args).await;
+        let ret = paru::run(args.iter()).await;
         assert_eq!(ret, 0);
     }
 
     args.extend(run_args);
-    let ret = paru::run(&args).await;
+    let ret = paru::run(args.iter()).await;
 
     for pkg in std::fs::read_dir(dir.join("cache/pkg"))? {
         let path = pkg?.path();


### PR DESCRIPTION
A quick pass over the whole codebase looking for iterators that are .collect()-ed unnecessarily, or where type inference can get rid of the turbofish.

I formatted my code with cargo fmt, all tests pass.