### PR TITLE
Force to recompute the signature

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -651,7 +651,7 @@ impl Installer {
             .chain(debug_paths.values())
             .map(|s| s.as_str())
             .collect::<Vec<_>>();
-        sign_pkg(config, &paths, false)?;
+        sign_pkg(config, &paths, true)?;
 
         if let Some(ref repo) = repo {
             if let Some(repo) = self.upgrades.aur_repos.get(base.package_base()) {


### PR DESCRIPTION
When rebuilding a package with a local repo, the signature is not overwritten with a new one. This means that the new pkg is added to the repo but the old signature is kept, which is invalid with the new build.

This change forces to overwrite the old signature with the new recomputed one.