### PR TITLE
Remove unnecessary --bind-ro for makepkg.conf.d in chroot.rs

### DIFF
--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -91,11 +91,6 @@ impl Chroot {
             .arg(&self.makepkg_conf)
             .arg(dir);
 
-        if Path::new(&format!("{}.d", self.makepkg_conf)).exists() {
-            cmd.arg("--bind-ro");
-            cmd.arg(format!("{}.d:/etc/makepkg.conf.d", self.makepkg_conf));
-        }
-
         for file in &self.ro {
             cmd.arg("--bind-ro");
             cmd.arg(file);


### PR DESCRIPTION
This block was added in [25ab260](https://github.com/Morganamilo/paru/commit/25ab26082be7fcc6bac86b815e51f034203ea248), 9 months ago, to fix #1156 (`makepkg.conf.d/` not copied by `arch-nspawn`). The `devtools` package was updated 6 months ago to add support for this in [archlinux/devtools@96eff02](https://github.com/archlinux/devtools/commit/96eff0280136e62a22095694255543cbfab01586) and the 1.3.2 version with this feature was released on the same day. The two listed alternative providers for the `devtools` dependency (`devtools-doas` and `devtools-git`) have had this feature for the same timespan.

We can remove this band-aid and let `arch-nspawn` take care of both `makepkg.conf` and `makepkg.conf.d/`, which resolves the slight inconsistency (when one is modified during a chroot build) in the way these behave.
