### PR TITLE
Fix duplicate `--sysroot` argument

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -3,7 +3,6 @@ use std::fmt::{Display, Formatter, Result};
 
 pub static PACMAN_FLAGS: &[&str] = &[
     "disable-download-timeout",
-    "sysroot",
     "d",
     "nodeps",
     "assume-installed",


### PR DESCRIPTION
Running `paru -Syu --sysroot foo` results in this pacman call: `sudo pacman --sync -y -u --sysroot=foo --sysroot=foo --`

This seems to be caused by `"sysroot"` being contained in both, `PACMAN_FLAGS` and `PACMAN_GLOBALS`:

https://github.com/Morganamilo/paru/blob/93d7e7652526765891f61581d13ce0c20cbfe379/src/args.rs#L6
https://github.com/Morganamilo/paru/blob/93d7e7652526765891f61581d13ce0c20cbfe379/src/args.rs#L88

This causes `arg.is_pacman_global()` _and_ `arg.is_pacman_arg()` to return true, adding `"sysroot"` to `self.args.args` twice:

https://github.com/Morganamilo/paru/blob/93d7e7652526765891f61581d13ce0c20cbfe379/src/command_line.rs#L142C1-L158C10

This behavior doesn't seem to cause errors, but also doesn't seem to make sense. It's probably a minor bug. I'm not entirely sure, but removing `"sysroot"` from `PACMAN_FLAGS` seems to be the correct solution to me. As far as I can tell this is a global parameter, similar to `--root` or `--color`.

FYI: I also checked, there is no other overlap between `PACMAN_FLAGS` and `PACMAN_GLOBALS`. So this was really the only case.