### PR TITLE
chore: remove use of bail in clean.rs (unused use/dependency)

### DIFF
--- a/src/clean.rs
+++ b/src/clean.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use std::process::Command;
 
 use alpm_utils::DbListExt;
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use srcinfo::Srcinfo;
 use tr::tr;
 


### PR DESCRIPTION
Dependency isn't used anymore, as removed in d741758ace94d0fbf1e62b7759820ba0b1197ef6 (https://github.com/Morganamilo/paru/pull/1422)