### PR TITLE
feat: add --basechrootpkgs to customize chroot base packages

### DIFF
--- a/man/paru.8
+++ b/man/paru.8
@@ -420,7 +420,21 @@ Note that this is only a temp fix and only applies to this one build. You should
 ideally patch the package yourself or report the problem to the maintainer.
 
 If you want to permanently add a package to the chroot use \fBparu -Ci package\fR
-to install packages into the master chroot.
+to install packages into the root chroot, or use \-\-rootchrootpkgs to specify
+packages that should be installed when the chroot is created.
+
+.TP
+.B \-\-rootchrootpkgs <packages>
+Comma-separated list of packages to install when creating the root chroot.
+
+Defaults to "base-devel" if not specified.
+
+Unlike \-\-chrootpkgs (which installs packages temporarily before each build),
+\-\-rootchrootpkgs packages become part of the root chroot and persist across
+all builds.
+
+This only affects chroot creation. To apply changes to an existing chroot,
+you must delete and recreate it.
 
 .TP
 .B \-\-completioninterval <days>

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -363,6 +363,19 @@ where makechrootpkg is called by paru. Arguments are split on whitespace before
 being passed to makechrootpkg.
 
 .TP
+.B RootChrootPkgs = Packages...
+Space-separated list of packages to install when creating the root chroot.
+
+Defaults to "base-devel" if not specified.
+
+Unlike \-\-chrootpkgs (which installs packages temporarily before each build),
+\-\-rootchrootpkgs packages become part of the root chroot and persist across
+all builds.
+
+This only affects chroot creation. To apply changes to an existing chroot,
+you must delete and recreate it.
+
+.TP
 .B Pager = Command
 Command to use for paging
 

--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -19,6 +19,7 @@ pub struct Chroot {
     pub ro: Vec<String>,
     pub rw: Vec<String>,
     pub extra_pkgs: Vec<String>,
+    pub root_pkgs: Vec<String>,
 }
 
 fn pacman_conf(pacman_conf: &str) -> Result<tempfile::NamedTempFile> {
@@ -44,7 +45,7 @@ impl Chroot {
         self.path.join("root").exists()
     }
 
-    pub fn create<S: AsRef<OsStr>>(&self, config: &Config, pkgs: &[S]) -> Result<()> {
+    pub fn create(&self, config: &Config) -> Result<()> {
         let mut cmd = Command::new(&config.sudo_bin);
         cmd.arg("install").arg("-dm755").arg(&self.path);
         exec::command(&mut cmd)?;
@@ -59,7 +60,7 @@ impl Chroot {
             .arg("-M")
             .arg(&self.makepkg_conf)
             .arg(dir)
-            .args(pkgs);
+            .args(&self.root_pkgs);
 
         exec::command(&mut cmd)?;
         Ok(())

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -198,6 +198,9 @@ impl Config {
             Arg::Long("chrootpkgs") => self
                 .chroot_pkgs
                 .extend(value?.split(',').map(|s| s.to_string())),
+            Arg::Long("rootchrootpkgs") => self
+                .root_chroot_pkgs
+                .extend(value?.split(',').map(|s| s.to_string())),
 
             Arg::Long("develsuffixes") => self.devel_suffixes = split_whitespace(value?),
             Arg::Long("installdebug") => self.install_debug = true,
@@ -412,6 +415,7 @@ fn takes_value(arg: Arg) -> TakesValue {
         Arg::Long("fmflags") => TakesValue::Required,
         Arg::Long("chrootflags") => TakesValue::Required,
         Arg::Long("chrootpkgs") => TakesValue::Required,
+        Arg::Long("rootchrootpkgs") => TakesValue::Required,
         Arg::Long("completioninterval") => TakesValue::Required,
         Arg::Long("sortby") => TakesValue::Required,
         Arg::Long("searchby") => TakesValue::Required,

--- a/src/config.rs
+++ b/src/config.rs
@@ -516,6 +516,8 @@ pub struct Config {
     pub chroot_dir: PathBuf,
     pub chroot: bool,
     pub chroot_pkgs: Vec<String>,
+    #[default(vec!["base-devel".to_string()])]
+    pub root_chroot_pkgs: Vec<String>,
     pub install: bool,
     pub uninstall: bool,
     pub sysupgrade: bool,
@@ -1100,6 +1102,10 @@ then initialise it with:
             .ok_or_else(|| anyhow!(tr!("value can not be empty for key '{}'", key)));
 
         match key {
+            "RootChrootPkgs" => {
+                self.root_chroot_pkgs
+                    .extend(value?.split_whitespace().map(|s| s.to_string()));
+            }
             "AurUrl" => self.aur_url = value?.parse()?,
             "AurRpcUrl" => self.aur_rpc_url = Some(value?.parse()?),
             "BuildDir" | "CloneDir" => self.build_dir = PathBuf::from(value?),

--- a/src/help.rs
+++ b/src/help.rs
@@ -86,6 +86,9 @@ pub fn help() {
     printtr!("    --[no]signdb           Sign databases with gpg");
     printtr!("    --[no]localrepo        Build packages into a local repo");
     printtr!("    --nocheck              Don't resolve checkdepends or run the check function");
+    printtr!(
+        "    --rootchrootpkgs       Packages to install in the root chroot (default: base-devel)"
+    );
     printtr!("    --develsuffixes        Suffixes used to decide if a package is a devel package");
     printtr!("    --ignoredevel          Ignore devel upgrades for specified packages");
     printtr!("    --bottomup             Shows AUR's packages first and then repository's");

--- a/src/install.rs
+++ b/src/install.rs
@@ -856,7 +856,7 @@ impl Installer {
 
         if config.chroot {
             if !self.chroot.exists() {
-                self.chroot.create(config, &["base-devel"])?;
+                self.chroot.create(config)?;
             } else {
                 self.chroot.update()?;
             }
@@ -1851,6 +1851,7 @@ fn chroot(config: &Config) -> Chroot {
         ro: repo::all_files(config),
         rw: config.pacman.cache_dir.clone(),
         extra_pkgs: config.chroot_pkgs.clone(),
+        root_pkgs: config.root_chroot_pkgs.clone(),
     };
 
     if config.args.count("d", "nodeps") > 1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,6 +429,7 @@ fn handle_chroot(config: &Config) -> Result<i32> {
         ro: repo::all_files(config),
         rw: config.pacman.cache_dir.clone(),
         extra_pkgs: config.chroot_pkgs.clone(),
+        root_pkgs: config.root_chroot_pkgs.clone(),
     };
 
     if config.print {
@@ -437,7 +438,7 @@ fn handle_chroot(config: &Config) -> Result<i32> {
     }
 
     if !chroot.exists() {
-        chroot.create(config, &["base-devel"])?;
+        chroot.create(config)?;
     }
 
     if config.sysupgrade {


### PR DESCRIPTION
Introduces a new --basechrootpkgs flag and BaseChrootPkgs config option to allow customization of packages installed when creating the base chroot.

This solves the problem of multilib packages failing to build in chroot environments because multilib-devel was not available in the default base-devel installation.

Related: #1355