### PR TITLE
fix: handle PkgNotFound gracefully in query operations

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -52,7 +52,11 @@ pub async fn print_upgrade_list(config: &mut Config) -> Result<i32> {
         }
 
         let mut args = config.pacman_args();
-        args.remove("u").remove("upgrades").arg("q");
+        args.remove("u")
+            .remove("upgrades")
+            .remove("i")
+            .remove("info")
+            .arg("q");
         args.targets = aur.into_iter().collect();
         let output = exec::pacman_output(config, &args)?;
         let aur = String::from_utf8(output.stdout)?;


### PR DESCRIPTION
Fixes crash when running paru -Qui on systems with inconsistent package database state.

The crash occurred because db.pkg(target) would return PkgNotFound error for packages that were removed or in an inconsistent state, and the unwrap would panic instead of handling the error.

Fixes #1340