### PR TITLE
Don't rely on transparent decompression in list_aur

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,6 +1509,7 @@ dependencies = [
  "cini",
  "dirs",
  "env_logger",
+ "flate2",
  "futures",
  "globset",
  "htmlescape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ regex = "1.11.1"
 signal-hook = "0.3.18"
 bitflags = "2.9.1"
 toml = { version = "0.8.23", features = ["preserve_order"] }
+flate2 = "1.1"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
The current AUR package list code relies on the reqwest client library to transparently decompress the packages.gz file. This only works if the server provides the 'Content-Encoding: gzip" HTTP header, which appears to have changed recently.

This patch explicitly decompresses the package list if no encoding information is provided by the server.

Fixes: https://github.com/Morganamilo/paru/issues/1447