### PR TITLE
Change default sort mode to BottomUp (AUR-first) and update manpage

### DIFF
--- a/man/paru.8
+++ b/man/paru.8
@@ -461,7 +461,7 @@ Don't skip the review process.
 .TP
 .B \-\-upgrademenu
 Show a detailed list of updates in a similar format to pacman's VerbosePkgLists
-option. (See 
+option. (See
 .BR pacman.conf(5)).
 Upgrades can be skipped using numbers, number ranges, or repo
 names.
@@ -487,12 +487,12 @@ Don't remove makedepends after installing packages.
 
 .TP
 .B \-\-topdown
-Print search results from top to bottom. Repo packages will print first. This
-is the default.
+Print search results from top to bottom. Repo packages will print first.
 
 .TP
 .B \-\-bottomup
-Print search results from bottom to top. AUR packages will print first.
+Print search results from bottom to top. AUR packages will print first. This
+is the default.
 
 .TP
 .B \-\-limit <limit>
@@ -541,7 +541,7 @@ Do not check for development packages updates during sysupgrade.
 
 .TP
 .B \-\-develsuffixes
-Suffixes that paru will use to decide if a package is a devel package. 
+Suffixes that paru will use to decide if a package is a devel package.
 Used when determining if a pkgver bump is used when the --needed option is
 set.
 
@@ -601,7 +601,7 @@ Print new news during sysupgrade.
 .TP
 .B \-\-useask
 Use pacman's --ask flag to automatically confirm package conflicts. Paru lists
-conflicts ahead of time. It is possible that paru does not detect a conflict, 
+conflicts ahead of time. It is possible that paru does not detect a conflict,
 causing a package to be removed without the user's confirmation. However, this
 is very unlikely.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -431,7 +431,7 @@ pub struct Config {
     #[default(raur::SearchBy::NameDesc)]
     pub search_by: raur::SearchBy,
     pub limit: usize,
-    #[default(SortMode::TopDown)]
+    #[default(SortMode::BottomUp)]
     pub sort_mode: SortMode,
     #[default(Mode::empty())]
     pub mode: Mode,


### PR DESCRIPTION
What: Change default sort mode to BottomUp so interactive searches show AUR packages first. Update man/paru.8 to reflect new default.

Why: Matches common user expectations (yay-like AUR-first). Users can still override via CLI flags or config.

Testing: Built with cargo build --release and verified interactive behavior.