### PR TITLE
feat: add explicit HTTP proxy support for AUR requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
@@ -351,9 +351,9 @@ checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "console"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "dtoa-short"
@@ -1118,9 +1118,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
+checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
 dependencies = [
  "jiff-static",
  "log",
@@ -1131,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
+checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1158,9 +1158,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.179"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libloading"
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
@@ -1595,9 +1595,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1994,10 +1994,11 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 

--- a/man/paru.8
+++ b/man/paru.8
@@ -303,6 +303,17 @@ Set an alternative AUR URL.
 Set an alternative URL for the AUR /rpc endpoint.
 
 .TP
+.B \-\-proxy <url>
+Override proxy for paru's HTTP requests to the AUR. Supports http://,
+https://, and socks5:// schemes. Paru respects standard proxy environment
+variables by default; this option overrides them. Does not affect git or pacman.
+
+.TP
+.B \-\-noproxy <hosts>
+Comma-separated list of hosts to bypass the proxy. Only applies when --proxy
+is set.
+
+.TP
 .B \-\-clonedir <dir>
 Directory used to download and run PKGBUILDs.
 

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -8,7 +8,7 @@ paru.conf \- paru configuration file
 $PARU_CONF, $XDG_CONFIG_HOME/paru/paru.conf, $HOME/.config/paru/paru.conf, /etc/paru.conf
 
 .SH DESCRIPTION
-Paru's config file. Based on the format used by 
+Paru's config file. Based on the format used by
 .BR pacman.conf (5)
 
 Paru first attempts to read the file at $PARU_CONF. If $PARU_CONF is not
@@ -178,7 +178,7 @@ during builds allowing an option to be chosen then.
 .TP
 .B UpgradeMenu
 Show a detailed list of updates in a similar format to pacman's VerbosePkgLists
-option. (See 
+option. (See
 .BR pacman.conf(5)).
 Upgrades can be skipped using numbers, number ranges, or repo
 names.
@@ -197,6 +197,28 @@ Set an alternative AUR URL.
 Set an alternative URL for the AUR /rpc endpoint.
 
 .TP
+.B Proxy = URL
+Set an explicit proxy URL for paru's HTTP requests to the AUR (RPC queries,
+package lists, PKGBUILDs). Supports http://, https://, and socks5:// schemes.
+.sp
+Paru automatically respects the standard proxy environment variables
+(HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, NO_PROXY). This option is only needed if
+you want to override the environment or use a different proxy specifically
+for AUR requests.
+.sp
+This does \fBnot\fR affect git operations (cloning/fetching AUR repos) or
+pacman downloads. Git and pacman also respect standard proxy environment
+variables. For git-specific configuration, use \fBgit config --global
+http.proxy\fR.
+
+.TP
+.B NoProxy = hosts
+Comma-separated list of hosts to bypass the proxy. Only applies when Proxy is
+set. Supports IP addresses, CIDR notation (e.g., 192.168.1.0/24), domain names,
+and wildcards.
+Example: localhost,127.0.0.1,.local
+
+.TP
 .B CloneDir = /path/to/dir
 Directory used to download and run PKGBUILDs.
 
@@ -208,7 +230,7 @@ visible here: https://aur.archlinux.org/packages/
 
 .TP
 .B SearchBy = <name|name-desc|maintainer|depends|checkdepends|makedepends|optdepends>
-Defaults to name-desc. Search AUR packages according to the options in 
+Defaults to name-desc. Search AUR packages according to the options in
 "Search by" visible here: https://aur.archlinux.org/packages/
 
 .TP

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -173,6 +173,8 @@ impl Config {
             Arg::Long("version") | Arg::Short('V') => self.version = true,
             Arg::Long("aururl") => self.aur_url = Url::parse(value?)?,
             Arg::Long("aurrpcurl") => self.aur_rpc_url = Some(Url::parse(value?)?),
+            Arg::Long("proxy") => self.proxy = Some(value?.to_string()),
+            Arg::Long("noproxy") => self.no_proxy = Some(value?.to_string()),
             Arg::Long("makepkg") => self.makepkg_bin = value?.to_string(),
             Arg::Long("pacman") => self.pacman_bin = value?.to_string(),
             Arg::Long("pacman-conf") => self.pacman_conf_bin = Some(value?.to_string()),
@@ -395,6 +397,8 @@ fn takes_value(arg: Arg) -> TakesValue {
     match arg {
         Arg::Long("aururl") => TakesValue::Required,
         Arg::Long("aurrpcurl") => TakesValue::Required,
+        Arg::Long("proxy") => TakesValue::Required,
+        Arg::Long("noproxy") => TakesValue::Required,
         Arg::Long("editor") => TakesValue::Required,
         Arg::Long("makepkg") => TakesValue::Required,
         Arg::Long("pacman") => TakesValue::Required,

--- a/src/help.rs
+++ b/src/help.rs
@@ -38,6 +38,8 @@ pub fn help() {
     );
     printtr!("    --aururl    <url>      Set an alternative AUR URL");
     printtr!("    --aurrpcur  <url>      Set an alternative URL for the AUR /rpc endpoint");
+    printtr!("    --proxy     <url>      Set HTTP proxy for AUR requests");
+    printtr!("    --noproxy   <list>     Comma-separated hosts to bypass proxy");
     printtr!("    --clonedir  <dir>      Directory used to download and run PKGBUILDs");
     println!();
     printtr!("    --makepkg   <file>     makepkg command to use");

--- a/src/install.rs
+++ b/src/install.rs
@@ -1801,12 +1801,13 @@ pub fn review(config: &Config, fetch: &aur_fetch::Fetch, pkgs: &[&str]) -> Resul
 }
 
 fn update_aur_list(config: &Config) {
+    let client = config.raur.client().clone();
     let url = config.aur_url.clone();
     let dir = config.cache_dir.clone();
     let interval = config.completion_interval;
 
     tokio::spawn(async move {
-        let _ = update_aur_cache(&url, &dir, Some(interval)).await;
+        let _ = update_aur_cache(&client, &url, &dir, Some(interval)).await;
     });
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -12,7 +12,6 @@ use flate2::read::GzDecoder;
 use indicatif::HumanBytes;
 use raur::{Raur, SearchBy};
 use regex::RegexSet;
-use reqwest::get;
 use srcinfo::Srcinfo;
 use tr::tr;
 
@@ -167,7 +166,10 @@ async fn search_target(config: &Config, targets: &mut Vec<String>) -> Result<Vec
 
 async fn search_aur_regex(config: &Config, targets: &[String]) -> Result<Vec<raur::Package>> {
     let url = config.aur_url.join("packages.gz")?;
-    let resp = get(url.clone())
+    let client = config.raur.client();
+    let resp = client
+        .get(url.clone())
+        .send()
         .await
         .with_context(|| format!("get {}", url))?;
     let success = resp.status().is_success();


### PR DESCRIPTION
Add Proxy and NoProxy configuration options for paru's HTTP requests to the AUR. This addresses issues where automatic proxy detection via environment variables (HTTP_PROXY/HTTPS_PROXY) fails with reqwest.

Supported proxy schemes: http://, https://, socks5://

This only affects paru's direct HTTP requests (RPC queries, packages.gz, PKGBUILDs). Git clone/fetch operations and pacman downloads use their respective separate proxy configuration.

Closes #1473