### PR TITLE
fix: decompress packages.gz for completion cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,9 +593,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1294,6 +1294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1509,6 +1510,7 @@ dependencies = [
  "cini",
  "dirs",
  "env_logger",
+ "flate2",
  "futures",
  "globset",
  "htmlescape",
@@ -2007,6 +2009,12 @@ checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ ansiterm = "0.12.2"
 anyhow = { version = "1.0.98", features = ["backtrace"] }
 chrono = { version = "0.4.41", default-features = false, features = ["clock"] }
 dirs = "6.0.0"
+flate2 = "1.0"
 futures = "0.3.31"
 globset = "0.4.16"
 htmlescape = "0.3.1"


### PR DESCRIPTION
AUR changed how packages.gz is served to no longer include the Content-Encoding: gzip header, so HTTP clients no longer auto-decompress the response. This caused raw gzip binary data (including null bytes) to be written to the completion cache, resulting in bash warnings: "command substitution: ignored null byte in input"

Fixes: #1472, #1450