### PR TITLE
feat(sort): add --auto sorting and restrict to interactive menus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
@@ -351,9 +351,9 @@ checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "console"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "dtoa-short"
@@ -1118,9 +1118,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
+checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
 dependencies = [
  "jiff-static",
  "log",
@@ -1131,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
+checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1158,9 +1158,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.179"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libloading"
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
@@ -1595,9 +1595,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1994,10 +1994,11 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,13 +281,28 @@ impl ConfigEnum for raur::SearchBy {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SortMode {
+    Auto,
     BottomUp,
     TopDown,
 }
 
 impl ConfigEnum for SortMode {
-    const VALUE_LOOKUP: ConfigEnumValues<Self> =
-        &[("bottomup", Self::BottomUp), ("topdown", Self::TopDown)];
+    const VALUE_LOOKUP: ConfigEnumValues<Self> = &[
+        ("auto", Self::Auto),
+        ("bottomup", Self::BottomUp),
+        ("topdown", Self::TopDown),
+    ];
+}
+
+impl SortMode {
+    pub fn is_top_down(self, interactive: bool) -> bool {
+        match (self, interactive) {
+            (SortMode::TopDown, _) => true,
+            (SortMode::BottomUp, _) => false,
+            (SortMode::Auto, true) => false,
+            (SortMode::Auto, false) => true,
+        }
+    }
 }
 
 bitflags! {
@@ -431,7 +446,7 @@ pub struct Config {
     #[default(raur::SearchBy::NameDesc)]
     pub search_by: raur::SearchBy,
     pub limit: usize,
-    #[default(SortMode::TopDown)]
+    #[default(SortMode::Auto)]
     pub sort_mode: SortMode,
     #[default(Mode::empty())]
     pub mode: Mode,
@@ -1041,6 +1056,7 @@ then initialise it with:
         match key {
             "SkipReview" => self.skip_review = true,
             "BottomUp" => self.sort_mode = SortMode::BottomUp,
+            "TopDown" => self.sort_mode = SortMode::TopDown,
             "AurOnly" => self.mode = Mode::AUR,
             "PkgbuildsOnly" => self.mode = Mode::PKGBUILD,
             "RepoOnly" => self.mode = Mode::REPO,

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,4 +1,4 @@
-use crate::config::{Colors, Config, SortMode, YesNoAll};
+use crate::config::{Colors, Config, YesNoAll};
 use crate::exec::has_command;
 use crate::fmt::print_indent;
 use crate::util::is_arch_repo;
@@ -480,7 +480,7 @@ pub async fn show_comments(config: &mut Config) -> Result<i32> {
 
         let iter = titles.zip(comments).collect::<Vec<_>>();
 
-        if config.sort_mode == SortMode::TopDown {
+        if config.sort_mode.is_top_down(false) {
             for (title, comment) in iter.into_iter() {
                 print_indent(c.bold, 0, 0, config.cols, " ", title.split_whitespace());
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
+use crate::config::Config;
 use crate::config::SortBy;
-use crate::config::{Config, SortMode};
 use crate::fmt::{color_repo, link_str, print_indent};
 use crate::util::{input, is_arch_repo, NumberMenu};
 use crate::{info, printtr};
@@ -53,7 +53,7 @@ pub async fn search(config: &Config) -> Result<i32> {
         }
     };
 
-    if config.sort_mode == SortMode::TopDown {
+    if config.sort_mode.is_top_down(false) {
         for pkg in &repo_pkgs {
             print_alpm_pkg(config, pkg, quiet);
         }
@@ -515,7 +515,7 @@ pub fn interactive_menu(
         all_pkgs.insert(0, pkg);
     }
 
-    if config.sort_mode == SortMode::TopDown {
+    if config.sort_mode.is_top_down(true) {
         for (n, pkg) in all_pkgs.iter().enumerate() {
             print_any_pkg(config, n, pad, pkg)
         }
@@ -538,7 +538,7 @@ pub fn interactive_menu(
     let menu = NumberMenu::new(&input);
     let mut pkgs = Vec::new();
 
-    if config.sort_mode == SortMode::TopDown {
+    if config.sort_mode.is_top_down(true) {
         for (n, pkg) in all_pkgs.iter().enumerate() {
             if menu.contains(n + 1, "") {
                 match pkg {


### PR DESCRIPTION
Users have requested --bottomup as the default sorting behavior. However, paru wraps pacman and should mimic its behavior, which uses topdown ordering.

As a compromise, introduce a new default "Auto" sort mode.
- TopDown ordering for non-interactive operations
- BottomUp ordering for interactive menus where users select packages