### PR TITLE
Compatible with Rust 2024 Edition 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "paru"
 version = "2.1.0"
 authors = ["morganamilo <morganamilo@archlinux.org>"]
-edition = "2021"
+edition = "2024"
 
 description = "Feature packed AUR helper"
 homepage = "https://github.com/Morganamilo/paru"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ aur-depends = "5.0.0"
 aur-fetch = "0.11.3"
 cini = "1.0.0"
 pacmanconf = "3.1.0"
-raur = "7.0.0"
+raur = { version = "8.0.0" , default-features = false, features = ["reqwest", "async", "native-tls"] }
 srcinfo = "2.1.0"
 
 
@@ -35,7 +35,7 @@ htmlescape = "0.3.1"
 indicatif = "0.18.3"
 scraper = "0.25.0"
 nix = { version = "0.30.1", features = ["fs", "user"] }
-reqwest = { version = "0.11.27", features = ["gzip", "socks"] }
+reqwest = { version = "0.13.1", default-features = false, features = ["rustls-no-provider", "form", "gzip", "socks", "charset", "http2", "system-proxy"] }
 rss = { version = "2.0.12", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
@@ -78,3 +78,4 @@ mock_chroot = ["mock"]
 #aur-depends = { path = "../aur-depends" }
 #srcinfo = { path = "../srcinfo.rs" }
 #aur-fetch = { path = "../aur-fetch" }
+#raur = { path = "../raur" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -836,7 +836,8 @@ then initialise it with:
         }
 
         if self.chroot {
-            remove_var("PKGEXT");
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { remove_var("PKGEXT") };
         }
 
         Ok(())
@@ -995,7 +996,8 @@ then initialise it with:
         );
 
         self.env.push((key.to_owned(), value.to_string()));
-        set_var(key, value);
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { set_var(key, value) };
         Ok(())
     }
 

--- a/src/devel.rs
+++ b/src/devel.rs
@@ -296,15 +296,15 @@ async fn ls_remote(
     let future = ls_remote_internal(git, flags, remote, branch);
     let future = timeout(time, future);
 
-    if let Ok(v) = future.await {
+    match future.await { Ok(v) => {
         v
-    } else {
+    } _ => {
         print_error(
             style,
             anyhow!("timed out looking for devel update: {}", remote),
         );
         bail!("")
-    }
+    }}
 }
 
 fn parse_url(source: &str) -> Option<(String, &'_ str, Option<&'_ str>)> {


### PR DESCRIPTION
Once the raur update is adopted and the version number is updated to 8.0.0, we can support Rust 2024 Edition by updating the raur version to 8.0.0 in both paru and aur-depends.

https://github.com/Morganamilo/aur-depends/pull/24
https://gitlab.com/davidbittner/raur/-/merge_requests/30
