### PR TITLE
feat: add ability to override configs per-package

### DIFF
--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -439,3 +439,81 @@ Skip review for this repository.
 .B GenerateSrcinfo
 Force regeneration of the .SRCINFO file even if it exists on disk. This is useful for
 repositories that forget to update their .SRCINFO files.
+
+.SH PER-PACKAGE BUILD OVERRIDES
+Per-package build overrides allow customizing build settings for specific packages.
+There are two types of override sections: package overrides and group overrides.
+
+Package overrides always take precedence over group overrides. When multiple group
+overrides apply to the same package, later groups in the config file merge over
+earlier ones, with conflicting keys being overwritten.
+
+.SS PACKAGE OVERRIDES
+
+A package override section targets a single package by name:
+
+.RS
+\fB[override.package.\fR\fIpkgname\fR\fB]\fR
+.RE
+
+.TP
+.B MakepkgConf = /path/to/makepkg.conf
+Use a different makepkg.conf for building this package. This overrides the global
+MakepkgConf option for this package only.
+
+.TP
+.B Overrides = { KEY = value, KEY2 = "value2" }
+Set environment variables for building this package. Values may optionally be
+quoted with double quotes. Multiple key-value pairs are separated by commas.
+
+.SS GROUP OVERRIDES
+
+A group override section applies the same settings to multiple packages:
+
+.RS
+\fB[override.group.\fR\fIgroupname\fR\fB]\fR
+.RE
+
+.TP
+.B Packages = pkg1 pkg2 pkg3
+Space-separated list of package names this group applies to. This directive is
+required for group overrides.
+
+.TP
+.B MakepkgConf = /path/to/makepkg.conf
+Same as the package override equivalent.
+
+.TP
+.B Overrides = { KEY = value, KEY2 = "value2" }
+Same as the package override equivalent.
+
+.SS EXAMPLES
+
+Use a custom makepkg.conf for a specific package:
+
+.RS
+.nf
+[override.package.firefox]
+MakepkgConf = /etc/makepkg-pgo.conf
+.fi
+.RE
+
+Set custom compiler flags for a group of packages:
+
+.RS
+.nf
+[override.group.lto-builds]
+Packages = mesa vulkan-radeon
+MakepkgConf = /etc/makepkg-lto.conf
+Overrides = { MAKEFLAGS = "-j$(nproc)", CFLAGS = "-O3 -march=native" }
+.fi
+.RE
+
+Override environment variables for a single package:
+
+.RS
+.nf
+[override.package.linux-zen]
+Overrides = { MAKEFLAGS = "-j4", CARGO_BUILD_JOBS = "4" }
+.fi
+.RE

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -8,7 +8,7 @@ paru.conf \- paru configuration file
 $PARU_CONF, $XDG_CONFIG_HOME/paru/paru.conf, $HOME/.config/paru/paru.conf, /etc/paru.conf
 
 .SH DESCRIPTION
-Paru's config file. Based on the format used by 
+Paru's config file. Based on the format used by
 .BR pacman.conf (5)
 
 Paru first attempts to read the file at $PARU_CONF. If $PARU_CONF is not
@@ -178,7 +178,7 @@ during builds allowing an option to be chosen then.
 .TP
 .B UpgradeMenu
 Show a detailed list of updates in a similar format to pacman's VerbosePkgLists
-option. (See 
+option. (See
 .BR pacman.conf(5)).
 Upgrades can be skipped using numbers, number ranges, or repo
 names.
@@ -208,7 +208,7 @@ visible here: https://aur.archlinux.org/packages/
 
 .TP
 .B SearchBy = <name|name-desc|maintainer|depends|checkdepends|makedepends|optdepends>
-Defaults to name-desc. Search AUR packages according to the options in 
+Defaults to name-desc. Search AUR packages according to the options in
 "Search by" visible here: https://aur.archlinux.org/packages/
 
 .TP
@@ -465,6 +465,12 @@ MakepkgConf option for this package only.
 .B Overrides = { KEY = value, KEY2 = "value2" }
 Set environment variables for building this package. Values may optionally be
 quoted with double quotes. Multiple key-value pairs are separated by commas.
+
+.TP
+.B PkgbuildPatches = { https://url-patch.patch, /local/patch.patch }
+List patches for the PKGBUILD to apply to the PKGBUILD before building this
+package. You may for example add patches to the source of PKGBUILD by adding them
+locally then generating a PKGBUILD patch.
 
 .SS GROUP OVERRIDES
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use crate::pkgbuild::PkgbuildRepos;
 use crate::util::{get_provider, reopen_stdin};
 use crate::{alpm_debug_enabled, help, printtr, repo};
 
+use std::collections::HashMap;
 use std::env::consts::ARCH;
 use std::env::{remove_var, set_var, var};
 use std::fmt;
@@ -380,6 +381,27 @@ impl ConfigEnum for YesNoAllTree {
     ];
 }
 
+#[derive(Debug, Default, Clone)]
+pub struct PackageOverride {
+    pub makepkg_conf: Option<String>,
+    pub env: Vec<(String, String)>,
+}
+
+#[derive(Debug)]
+enum OverrideParseState {
+    Package {
+        name: String,
+        makepkg_conf: Option<String>,
+        env: Vec<(String, String)>,
+    },
+    Group {
+        name: String,
+        packages: Vec<String>,
+        makepkg_conf: Option<String>,
+        env: Vec<(String, String)>,
+    },
+}
+
 #[derive(SmartDefault, Debug)]
 pub struct Config {
     section: Option<String>,
@@ -529,6 +551,9 @@ pub struct Config {
 
     pub env: Vec<(String, String)>,
 
+    pub overrides: HashMap<String, PackageOverride>,
+    override_parse_state: Option<OverrideParseState>,
+
     //pacman
     pub db_path: Option<String>,
     pub root: Option<String>,
@@ -555,15 +580,40 @@ impl Ini for Config {
     fn callback(&mut self, cb: Callback) -> Result<(), Self::Err> {
         let err = match cb.kind {
             CallbackKind::Section(section) => {
+                self.finalize_override()?;
                 self.section = Some(section.to_string());
                 if !matches!(section, "options" | "bin" | "env")
                     && self.pkgbuild_repos.repo(section).is_none()
                 {
-                    if matches!(section, "local" | "aur" | "pkg" | "base") || section.contains('.')
-                    {
+                    if matches!(section, "local" | "aur" | "pkg" | "base") {
                         bail!(tr!("section can not be called {}", section));
                     }
-                    self.pkgbuild_repos.add_repo(section.to_string());
+                    if let Some(rest) = section.strip_prefix("override.package.") {
+                        ensure!(
+                            !rest.is_empty(),
+                            tr!("override.package section requires a package name")
+                        );
+                        self.override_parse_state = Some(OverrideParseState::Package {
+                            name: rest.to_string(),
+                            makepkg_conf: None,
+                            env: Vec::new(),
+                        });
+                    } else if let Some(rest) = section.strip_prefix("override.group.") {
+                        ensure!(
+                            !rest.is_empty(),
+                            tr!("override.group section requires a group name")
+                        );
+                        self.override_parse_state = Some(OverrideParseState::Group {
+                            name: rest.to_string(),
+                            packages: Vec::new(),
+                            makepkg_conf: None,
+                            env: Vec::new(),
+                        });
+                    } else if section.contains('.') {
+                        bail!(tr!("section can not be called {}", section));
+                    } else {
+                        self.pkgbuild_repos.add_repo(section.to_string());
+                    }
                 }
                 Ok(())
             }
@@ -663,6 +713,8 @@ impl Config {
     }
 
     pub fn parse_args<S: AsRef<str>, I: IntoIterator<Item = S>>(&mut self, iter: I) -> Result<()> {
+        self.finalize_override()?;
+
         let iter = iter.into_iter();
         let mut iter = iter.peekable();
         let mut op_count = 0;
@@ -959,6 +1011,10 @@ then initialise it with:
 
         let section = section.to_string();
 
+        if section.starts_with("override.") {
+            return self.parse_override_directive(key, value);
+        }
+
         match section.as_str() {
             "options" => self.parse_option(key, value),
             "bin" => self.parse_bin(key, value),
@@ -1158,6 +1214,112 @@ then initialise it with:
         Ok(())
     }
 
+    fn parse_override_directive(&mut self, key: &str, value: Option<&str>) -> Result<()> {
+        let state = self
+            .override_parse_state
+            .as_mut()
+            .context("override directive outside of override section")?;
+
+        match key {
+            "MakepkgConf" => {
+                let value = value
+                    .context(tr!("value can not be empty for key '{}'", key))?
+                    .to_string();
+                match state {
+                    OverrideParseState::Package { makepkg_conf, .. }
+                    | OverrideParseState::Group { makepkg_conf, .. } => {
+                        *makepkg_conf = Some(value);
+                    }
+                }
+            }
+            "Packages" => {
+                let value = value.context(tr!("value can not be empty for key '{}'", key))?;
+                match state {
+                    OverrideParseState::Package { .. } => {
+                        bail!(tr!(
+                            "'Packages' is not valid in [override.package.*] sections"
+                        ));
+                    }
+                    OverrideParseState::Group { packages, .. } => {
+                        packages.extend(value.split_whitespace().map(|s| s.to_string()));
+                    }
+                }
+            }
+            "Overrides" => {
+                let value = value.context(tr!("value can not be empty for key '{}'", key))?;
+                let parsed = parse_overrides_map(value)?;
+                match state {
+                    OverrideParseState::Package { env, .. }
+                    | OverrideParseState::Group { env, .. } => {
+                        env.extend(parsed);
+                    }
+                }
+            }
+            _ => eprintln!(
+                "{}",
+                tr!("error: unknown option '{}' in override section", key)
+            ),
+        }
+
+        Ok(())
+    }
+
+    fn finalize_override(&mut self) -> Result<()> {
+        let state = match self.override_parse_state.take() {
+            Some(s) => s,
+            None => return Ok(()),
+        };
+
+        match state {
+            OverrideParseState::Package {
+                name,
+                makepkg_conf,
+                env,
+            } => {
+                ensure!(
+                    makepkg_conf.is_some() || !env.is_empty(),
+                    tr!(
+                        "override.package.{} must have MakepkgConf or Overrides",
+                        name
+                    )
+                );
+                self.overrides
+                    .insert(name, PackageOverride { makepkg_conf, env });
+            }
+            OverrideParseState::Group {
+                name,
+                packages,
+                makepkg_conf,
+                env,
+            } => {
+                ensure!(
+                    !packages.is_empty(),
+                    tr!("override.group.{} must have a Packages directive", name)
+                );
+                ensure!(
+                    makepkg_conf.is_some() || !env.is_empty(),
+                    tr!("override.group.{} must have MakepkgConf or Overrides", name)
+                );
+                for pkg in packages {
+                    let entry = self.overrides.entry(pkg).or_default();
+                    // Group overrides merge: later groups overwrite conflicting keys
+                    if let Some(ref conf) = makepkg_conf {
+                        entry.makepkg_conf = Some(conf.clone());
+                    }
+                    for (k, v) in &env {
+                        if let Some(existing) = entry.env.iter_mut().find(|(ek, _)| ek == k) {
+                            existing.1 = v.clone();
+                        } else {
+                            entry.env.push((k.clone(), v.clone()));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn aur_namespace(&self) -> &str {
         if self.pacman.repos.iter().any(|r| r.name == "aur") {
             // hack for search install
@@ -1166,6 +1328,68 @@ then initialise it with:
             "aur"
         }
     }
+}
+
+fn parse_overrides_map(input: &str) -> Result<Vec<(String, String)>> {
+    let input = input.trim();
+    let inner = input
+        .strip_prefix('{')
+        .and_then(|s| s.strip_suffix('}'))
+        .context(tr!("Overrides value must be wrapped in { }"))?
+        .trim();
+
+    if inner.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut result = Vec::new();
+    let mut pairs = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    for ch in inner.chars() {
+        if ch == '"' {
+            in_quotes = !in_quotes;
+            current.push(ch);
+        } else if ch == ',' && !in_quotes {
+            pairs.push(std::mem::take(&mut current));
+        } else {
+            current.push(ch);
+        }
+    }
+    if !current.is_empty() {
+        pairs.push(current);
+    }
+
+    for pair in &pairs {
+        let pair = pair.trim();
+        if pair.is_empty() {
+            continue;
+        }
+        let (key, value) = pair
+            .split_once('=')
+            .context(tr!("invalid override entry, expected KEY = value"))?;
+        let key = key.trim().to_string();
+        let value = value.trim();
+        let value = value
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .unwrap_or(value)
+            .to_string();
+
+        ensure!(!key.is_empty(), tr!("override key can not be empty"));
+        ensure!(
+            !key.contains('\0'),
+            tr!("override key can not contain null bytes")
+        );
+        ensure!(
+            !value.contains('\0'),
+            tr!("override value can not contain null bytes")
+        );
+
+        result.push((key, value));
+    }
+
+    Ok(result)
 }
 
 pub fn version() {
@@ -1239,5 +1463,50 @@ fn log(level: LogLevel, msg: &str, color: &mut Colors) {
         LogLevel::ERROR => eprint!("{} {}", err.paint("error:"), msg),
         LogLevel::DEBUG if alpm_debug_enabled() => eprint!("debug: <alpm> {}", msg),
         _ => (),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_overrides_map_comma_in_quoted_value() {
+        let result = parse_overrides_map(r#"{ LDFLAGS = "-Wl,--as-needed" }"#).unwrap();
+        assert_eq!(
+            result,
+            vec![("LDFLAGS".to_string(), "-Wl,--as-needed".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_parse_overrides_map_comma_in_quoted_value_multiple() {
+        let result =
+            parse_overrides_map(r#"{ LDFLAGS = "-Wl,--as-needed", CFLAGS = "-O2" }"#).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                ("LDFLAGS".to_string(), "-Wl,--as-needed".to_string()),
+                ("CFLAGS".to_string(), "-O2".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_overrides_map_basic() {
+        let result = parse_overrides_map(r#"{ CFLAGS = "-O3", MAKEFLAGS = "-j8" }"#).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                ("CFLAGS".to_string(), "-O3".to_string()),
+                ("MAKEFLAGS".to_string(), "-j8".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_overrides_map_empty() {
+        let result = parse_overrides_map("{ }").unwrap();
+        assert!(result.is_empty());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use crate::exec::{self, Status};
 use crate::fmt::color_repo;
 use crate::info::get_terminal_width;
 use crate::pkgbuild::PkgbuildRepos;
-use crate::util::{get_provider, reopen_stdin};
+use crate::util::{get_provider, reopen_stdin, split_by_comma};
 use crate::{alpm_debug_enabled, help, printtr, repo};
 
 use std::collections::HashMap;
@@ -14,6 +14,7 @@ use std::fmt;
 use std::fs::{remove_file, OpenOptions};
 use std::io::{stderr, stdin, stdout, BufRead, IsTerminal};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::str::FromStr;
 
 use alpm::{
@@ -26,6 +27,7 @@ use anyhow::{anyhow, bail, ensure, Context, Error, Result};
 use bitflags::bitflags;
 use cini::{Callback, CallbackKind, Ini};
 use globset::{Glob, GlobSet, GlobSetBuilder};
+use reqwest::get;
 use tr::tr;
 use url::Url;
 
@@ -381,10 +383,90 @@ impl ConfigEnum for YesNoAllTree {
     ];
 }
 
+#[derive(Debug, Clone)]
+pub enum PatchSource {
+    Path(PathBuf),
+    Url(Url),
+}
+
+impl PatchSource {
+    pub async fn apply(&self, config: &Config, dir: &Path) -> Result<()> {
+        match self {
+            PatchSource::Path(path) => {
+                let patch_path = if path.is_absolute() {
+                    path.clone()
+                } else {
+                    dir.join(path)
+                };
+
+                let mut cmd = Command::new(&config.git_bin);
+                cmd.arg("apply").arg("-v").arg(&patch_path).current_dir(dir);
+
+                exec::command(&mut cmd)
+                    .with_context(|| tr!("failed to apply patch '{}'", patch_path.display()))?;
+            }
+            PatchSource::Url(url) => {
+                let bytes = get(url.clone())
+                    .await
+                    .with_context(|| tr!("Failed to download patch from {}", url))?
+                    .error_for_status()
+                    .with_context(|| tr!("Failed to download patch from {}", url))?
+                    .bytes()
+                    .await?;
+
+                // tempfile for patch.
+                let mut temp = tempfile::NamedTempFile::new()?;
+                use std::io::Write;
+                temp.write_all(&bytes)?;
+
+                let mut cmd = Command::new(&config.git_bin);
+                cmd.arg("apply").arg("-v").arg(temp.path()).current_dir(dir);
+
+                exec::command(&mut cmd)
+                    .with_context(|| tr!("failed to apply patch '{}'", temp.path().display()))?;
+            } // tempfile cleaned up safely by drop.
+        }
+
+        Ok(())
+    }
+}
+
+impl FromStr for PatchSource {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        if let Ok(url) = Url::parse(s) {
+            Ok(PatchSource::Url(url))
+        } else {
+            Ok(PatchSource::Path(PathBuf::from(s)))
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct PackageOverride {
     pub makepkg_conf: Option<String>,
     pub env: Vec<(String, String)>,
+    pub pkgbuild_patches: Vec<PatchSource>,
+}
+
+impl PackageOverride {
+    pub(crate) fn merge_from(&mut self, src: &PackageOverride) {
+        if src.makepkg_conf.is_some() {
+            self.makepkg_conf = src.makepkg_conf.clone();
+        }
+
+        for (k, v) in &src.env {
+            if let Some(existing) = self.env.iter_mut().find(|(ek, _)| ek == k) {
+                existing.1 = v.clone();
+            } else {
+                self.env.push((k.clone(), v.clone()));
+            }
+        }
+
+        self.pkgbuild_patches
+            .extend(src.pkgbuild_patches.iter().cloned());
+    }
 }
 
 #[derive(Debug)]
@@ -393,6 +475,7 @@ enum OverrideParseState {
         name: String,
         makepkg_conf: Option<String>,
         env: Vec<(String, String)>,
+        pkgbuild_patches: Vec<PatchSource>,
     },
     Group {
         name: String,
@@ -597,6 +680,7 @@ impl Ini for Config {
                             name: rest.to_string(),
                             makepkg_conf: None,
                             env: Vec::new(),
+                            pkgbuild_patches: Vec::new(),
                         });
                     } else if let Some(rest) = section.strip_prefix("override.group.") {
                         ensure!(
@@ -1255,6 +1339,22 @@ then initialise it with:
                     }
                 }
             }
+            "PkgbuildPatches" => {
+                let value = value.context(tr!("value can not be empty for key '{}'", key))?;
+                let parsed = parse_patches_list(value)?;
+                match state {
+                    OverrideParseState::Package {
+                        pkgbuild_patches, ..
+                    } => {
+                        pkgbuild_patches.extend(parsed);
+                    }
+                    OverrideParseState::Group { .. } => {
+                        bail!(tr!(
+                            "'PkgbuildPatches' is not valid in [override.group.*] sections"
+                        ));
+                    }
+                }
+            }
             _ => eprintln!(
                 "{}",
                 tr!("error: unknown option '{}' in override section", key)
@@ -1275,16 +1375,23 @@ then initialise it with:
                 name,
                 makepkg_conf,
                 env,
+                pkgbuild_patches,
             } => {
                 ensure!(
-                    makepkg_conf.is_some() || !env.is_empty(),
+                    makepkg_conf.is_some() || !env.is_empty() || !pkgbuild_patches.is_empty(),
                     tr!(
-                        "override.package.{} must have MakepkgConf or Overrides",
+                        "override.package.{} must have MakepkgConf, Overrides or PkgbuildPatches",
                         name
                     )
                 );
-                self.overrides
-                    .insert(name, PackageOverride { makepkg_conf, env });
+                self.overrides.insert(
+                    name,
+                    PackageOverride {
+                        makepkg_conf,
+                        env,
+                        pkgbuild_patches,
+                    },
+                );
             }
             OverrideParseState::Group {
                 name,
@@ -1302,7 +1409,6 @@ then initialise it with:
                 );
                 for pkg in packages {
                     let entry = self.overrides.entry(pkg).or_default();
-                    // Group overrides merge: later groups overwrite conflicting keys
                     if let Some(ref conf) = makepkg_conf {
                         entry.makepkg_conf = Some(conf.clone());
                     }
@@ -1343,22 +1449,7 @@ fn parse_overrides_map(input: &str) -> Result<Vec<(String, String)>> {
     }
 
     let mut result = Vec::new();
-    let mut pairs = Vec::new();
-    let mut current = String::new();
-    let mut in_quotes = false;
-    for ch in inner.chars() {
-        if ch == '"' {
-            in_quotes = !in_quotes;
-            current.push(ch);
-        } else if ch == ',' && !in_quotes {
-            pairs.push(std::mem::take(&mut current));
-        } else {
-            current.push(ch);
-        }
-    }
-    if !current.is_empty() {
-        pairs.push(current);
-    }
+    let pairs = split_by_comma(inner);
 
     for pair in &pairs {
         let pair = pair.trim();
@@ -1387,6 +1478,35 @@ fn parse_overrides_map(input: &str) -> Result<Vec<(String, String)>> {
         );
 
         result.push((key, value));
+    }
+
+    Ok(result)
+}
+
+fn parse_patches_list(input: &str) -> Result<Vec<PatchSource>> {
+    let input = input.trim();
+    let inner = input
+        .strip_prefix('{')
+        .and_then(|s| s.strip_suffix('}'))
+        .context(tr!("PkgbuildPatches value must be wrapped in { }"))?
+        .trim();
+
+    if inner.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let parts = split_by_comma(inner);
+
+    let mut result = Vec::new();
+    for part in parts {
+        let value = part
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .unwrap_or(part.as_str())
+            .to_string();
+
+        ensure!(!value.is_empty(), tr!("Patch source can not be empty"));
+        result.push(value.parse()?);
     }
 
     Ok(result)

--- a/src/install.rs
+++ b/src/install.rs
@@ -13,7 +13,7 @@ use crate::args::{Arg, Args};
 use crate::chroot::Chroot;
 use crate::clean::clean_untracked;
 use crate::completion::update_aur_cache;
-use crate::config::{Config, LocalRepos, Mode, Op, Sign, YesNoAllTree, YesNoAsk};
+use crate::config::{Config, LocalRepos, Mode, Op, PackageOverride, Sign, YesNoAllTree, YesNoAsk};
 use crate::devel::{fetch_devel_info, load_devel_info, save_devel_info, DevelInfo};
 use crate::download::{self, Bases};
 use crate::exec::{command_status, has_command};
@@ -535,10 +535,64 @@ impl Installer {
         repo: Option<(&str, &str)>,
         dir: &Path,
     ) -> Result<(HashMap<String, String>, String)> {
-        let c = config.color;
         let pkgdest = repo.map(|r| r.1);
+
+        // Apply per-package overrides
+        let pkg_override = get_base_override(config, base);
+        let saved_makepkg_conf = config.makepkg_conf.clone();
+        let saved_chroot_makepkg_conf = self.chroot.makepkg_conf.clone();
+
+        if let Some(ref ov) = pkg_override {
+            if let Some(ref conf) = ov.makepkg_conf {
+                config.makepkg_conf = Some(conf.clone());
+                if config.chroot {
+                    self.chroot.makepkg_conf = conf.clone();
+                }
+            }
+        }
+
+        let result = self.build_pkgbuild_inner(config, base, repo, dir, pkgdest, &pkg_override);
+
+        // Restore original config
+        config.makepkg_conf = saved_makepkg_conf;
+        self.chroot.makepkg_conf = saved_chroot_makepkg_conf;
+
+        result
+    }
+
+    fn build_pkgbuild_inner(
+        &mut self,
+        config: &mut Config,
+        base: &mut Base,
+        repo: Option<(&str, &str)>,
+        dir: &Path,
+        pkgdest: Option<&str>,
+        pkg_override: &Option<PackageOverride>,
+    ) -> Result<(HashMap<String, String>, String)> {
+        let c = config.color;
+
+        // Build merged env: config.env + override env + PKGDEST
         let mut env = config.env.clone();
+        if let Some(ref ov) = pkg_override {
+            for (k, v) in &ov.env {
+                if let Some(existing) = env.iter_mut().find(|(ek, _)| ek == k) {
+                    existing.1 = v.clone();
+                } else {
+                    env.push((k.clone(), v.clone()));
+                }
+            }
+        }
         env.extend(pkgdest.map(|p| ("PKGDEST".to_string(), p.to_string())));
+
+        // Set env vars for non-chroot builds
+        let _env_guard = if !config.chroot {
+            pkg_override
+                .as_ref()
+                .filter(|ov| !ov.env.is_empty())
+                .map(|ov| EnvGuard::new(&ov.env))
+        } else {
+            None
+        };
 
         if config.chroot {
             let mut extra = Vec::new();
@@ -549,7 +603,7 @@ impl Installer {
                 config.chroot_flags.iter().map(|s| s.as_str()).collect();
             chroot_flags.push("-cu");
             self.chroot
-                .build(dir, &extra, &chroot_flags, &["-ofA"], &config.env)
+                .build(dir, &extra, &chroot_flags, &["-ofA"], &env)
                 .with_context(|| tr!("failed to download sources for '{}'", base))?;
 
             if !self.chroot.extra_pkgs.is_empty() {
@@ -1250,6 +1304,58 @@ impl Installer {
 
     fn upgrade_later(&self, config: &Config) -> bool {
         config.mode.repo() && config.chroot && (self.sysupgrade != 0 || self.refresh != 0)
+    }
+}
+
+fn get_base_override(config: &Config, base: &Base) -> Option<PackageOverride> {
+    let mut result: Option<PackageOverride> = None;
+
+    for pkg_name in base.packages() {
+        if let Some(ov) = config.overrides.get(pkg_name) {
+            match result {
+                None => result = Some(ov.clone()),
+                Some(ref mut merged) => {
+                    if ov.makepkg_conf.is_some() {
+                        merged.makepkg_conf = ov.makepkg_conf.clone();
+                    }
+                    for (k, v) in &ov.env {
+                        if let Some(existing) = merged.env.iter_mut().find(|(ek, _)| ek == k) {
+                            existing.1 = v.clone();
+                        } else {
+                            merged.env.push((k.clone(), v.clone()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    result
+}
+
+struct EnvGuard {
+    saved: Vec<(String, Option<String>)>,
+}
+
+impl EnvGuard {
+    fn new(overrides: &[(String, String)]) -> Self {
+        let mut saved = Vec::new();
+        for (key, value) in overrides {
+            saved.push((key.clone(), std::env::var(key).ok()));
+            std::env::set_var(key, value);
+        }
+        EnvGuard { saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, old_value) in &self.saved {
+            match old_value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
     }
 }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -13,7 +13,9 @@ use crate::args::{Arg, Args};
 use crate::chroot::Chroot;
 use crate::clean::clean_untracked;
 use crate::completion::update_aur_cache;
-use crate::config::{Config, LocalRepos, Mode, Op, PackageOverride, Sign, YesNoAllTree, YesNoAsk};
+use crate::config::{
+    Config, LocalRepos, Mode, Op, PackageOverride, PatchSource, Sign, YesNoAllTree, YesNoAsk,
+};
 use crate::devel::{fetch_devel_info, load_devel_info, save_devel_info, DevelInfo};
 use crate::download::{self, Bases};
 use crate::exec::{command_status, has_command};
@@ -528,12 +530,13 @@ impl Installer {
     }
 
     // TODO: sort out args
-    fn build_pkgbuild(
+    async fn build_pkgbuild(
         &mut self,
         config: &mut Config,
         base: &mut Base,
         repo: Option<(&str, &str)>,
         dir: &Path,
+        cwd: &Path,
     ) -> Result<(HashMap<String, String>, String)> {
         let pkgdest = repo.map(|r| r.1);
 
@@ -549,6 +552,8 @@ impl Installer {
                     self.chroot.makepkg_conf = conf.clone();
                 }
             }
+
+            apply_patches(config, &cwd, &ov.pkgbuild_patches).await?;
         }
 
         let result = self.build_pkgbuild_inner(config, base, repo, dir, pkgdest, &pkg_override);
@@ -751,11 +756,12 @@ impl Installer {
         Ok(())
     }
 
-    fn build_install_pkgbuild(
+    async fn build_install_pkgbuild(
         &mut self,
         config: &mut Config,
         base: &mut Base,
         repo: Option<(&str, &str)>,
+        cwd: &Path,
     ) -> Result<()> {
         let dir = match base {
             Base::Aur(_) => config.build_dir.join(base.package_base()),
@@ -833,7 +839,7 @@ impl Installer {
         }
 
         let (mut pkgdest, version) = if build {
-            self.build_pkgbuild(config, base, repo, &dir)?
+            self.build_pkgbuild(config, base, repo, &dir, &cwd).await?
         } else {
             printtr!("{}: parsing pkg list...", base);
             let (pkgdests, version) = parse_package_list(config, &dir, pkgdest)?;
@@ -895,6 +901,7 @@ impl Installer {
         &mut self,
         config: &mut Config,
         build: &mut [Base],
+        cwd: &Path,
     ) -> Result<()> {
         if config.devel {
             printtr!("fetching devel info...");
@@ -927,9 +934,9 @@ impl Installer {
                 .as_ref()
                 .map(|(name, file)| (name.as_str(), file.as_str()));
 
-            let err = self.build_install_pkgbuild(config, base, repo_server);
+            let err = self.build_install_pkgbuild(config, base, repo_server, &cwd);
 
-            match err {
+            match err.await {
                 Ok(_) => {
                     self.failed.pop().unwrap();
                 }
@@ -994,8 +1001,8 @@ impl Installer {
             config.pkgbuild_repos.refresh(config)?;
             self.done_something = true;
         }
-        self.resolve_targets(config, &repo_targets, &aur_targets)
-            .await
+        let cwd = std::env::current_dir()?;
+        self.resolve_targets(config, &repo_targets, &aur_targets, &cwd).await
     }
 
     async fn resolve_targets<'a>(
@@ -1003,6 +1010,7 @@ impl Installer {
         config: &mut Config,
         repo_targets: &[Targ<'a>],
         aur_targets: &[Targ<'a>],
+        cwd: &Path,
     ) -> Result<()> {
         let mut cache = Cache::new();
         let flags = flags(config);
@@ -1039,7 +1047,7 @@ impl Installer {
 
         targets.extend(self.upgrades.repo_keep.iter().map(Targ::from));
 
-        if self.shoud_just_pacman(config.mode, aur_targets, &self.upgrades, self.ran_pacman) {
+        if self.should_just_pacman(config.mode, aur_targets, &self.upgrades, self.ran_pacman) {
             print_warnings(config, &cache, None);
             let mut args = config.pacman_args();
             let targets = targets.iter().map(|t| t.to_string()).collect::<Vec<_>>();
@@ -1086,7 +1094,7 @@ impl Installer {
         let mut err = Ok(());
 
         if !build.is_empty() {
-            err = self.build_install_pkgbuilds(config, &mut build).await;
+            err = self.build_install_pkgbuilds(config, &mut build, &cwd).await;
         }
 
         if err.is_ok() && config.chroot {
@@ -1102,7 +1110,7 @@ impl Installer {
         err
     }
 
-    fn shoud_just_pacman(
+    fn should_just_pacman(
         &self,
         mode: Mode,
         aur_targets: &[Targ<'_>],
@@ -1307,6 +1315,13 @@ impl Installer {
     }
 }
 
+async fn apply_patches(config: &Config, dir: &Path, patches: &[PatchSource]) -> Result<()> {
+    for patch in patches {
+        patch.apply(config, dir).await?;
+    }
+    Ok(())
+}
+
 fn get_base_override(config: &Config, base: &Base) -> Option<PackageOverride> {
     let mut result: Option<PackageOverride> = None;
 
@@ -1314,18 +1329,7 @@ fn get_base_override(config: &Config, base: &Base) -> Option<PackageOverride> {
         if let Some(ov) = config.overrides.get(pkg_name) {
             match result {
                 None => result = Some(ov.clone()),
-                Some(ref mut merged) => {
-                    if ov.makepkg_conf.is_some() {
-                        merged.makepkg_conf = ov.makepkg_conf.clone();
-                    }
-                    for (k, v) in &ov.env {
-                        if let Some(existing) = merged.env.iter_mut().find(|(ek, _)| ek == k) {
-                            existing.1 = v.clone();
-                        } else {
-                            merged.env.push((k.clone(), v.clone()));
-                        }
-                    }
-                }
+                Some(ref mut merged) => merged.merge_from(ov),
             }
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -400,3 +400,26 @@ pub fn is_arch_repo(name: &str) -> bool {
             | "multilib-testing"
     )
 }
+
+pub fn split_by_comma(inner: &str) -> Vec<String> {
+    let mut items = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+
+    for ch in inner.chars() {
+        if ch == '"' {
+            in_quotes = !in_quotes;
+            current.push(ch);
+        } else if ch == ',' && !in_quotes {
+            items.push(std::mem::take(&mut current));
+        } else {
+            current.push(ch);
+        }
+    }
+
+    if !current.is_empty() {
+        items.push(current);
+    }
+
+    items
+}

--- a/testdata/overrides/firefox-comment-addition.patch
+++ b/testdata/overrides/firefox-comment-addition.patch
@@ -1,0 +1,22 @@
+From 02db1a2f0f393209c4b8274de2755f12abe7859f Mon Sep 17 00:00:00 2001
+From: Toria <ninetailedtori@uwu.gal>
+Date: Sat, 18 Apr 2026 20:11:43 +0100
+Subject: [PATCH] Test comment, PKGBUILD for url test.
+
+Signed-off-by: Toria <ninetailedtori@uwu.gal>
+---
+ PKGBUILD | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/PKGBUILD b/PKGBUILD
+index 04f2e7d..a634854 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -1,3 +1,4 @@
++# This is for a test!
+ # Maintainer: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+ # Contributor: Ionut Biru <ibiru@archlinux.org>
+ # Contributor: Jakub Schmidtke <sjakub@gmail.com>
+-- 
+2.53.0
+

--- a/testdata/overrides/firefox-pkgrel-bump.patch
+++ b/testdata/overrides/firefox-pkgrel-bump.patch
@@ -1,0 +1,25 @@
+From cc955c6b5a182f8d0f0cd7dfa1cdc44bf5b0d11d Mon Sep 17 00:00:00 2001
+From: Toria <ninetailedtori@uwu.gal>
+Date: Sat, 18 Apr 2026 20:04:10 +0100
+Subject: [PATCH] PKGREL bump for paru test.
+
+Signed-off-by: Toria <ninetailedtori@uwu.gal>
+---
+ PKGBUILD | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/PKGBUILD b/PKGBUILD
+index 04f2e7d..ae4b0ee 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -4,7 +4,7 @@
+
+ pkgname=firefox
+ pkgver=149.0.2
+-pkgrel=1
++pkgrel=2
+ pkgdesc="Fast, Private & Safe Web Browser"
+ url="https://www.mozilla.org/firefox/"
+ arch=(x86_64)
+--
+2.53.0

--- a/testdata/paru.conf
+++ b/testdata/paru.conf
@@ -14,3 +14,12 @@ CARCH = x86_64
 
 [pkgbuild]
 Path = testdata/pkgbuild-repo
+
+[override.package.firefox]
+MakepkgConf = /etc/makepkg-pgo.conf
+Overrides = { CFLAGS = "-O3", MAKEFLAGS = "-j8" }
+
+[override.group.lto-builds]
+Packages = mesa vulkan-radeon
+MakepkgConf = /etc/makepkg-lto.conf
+Overrides = { CFLAGS = "-flto" }

--- a/testdata/paru.conf
+++ b/testdata/paru.conf
@@ -18,6 +18,7 @@ Path = testdata/pkgbuild-repo
 [override.package.firefox]
 MakepkgConf = /etc/makepkg-pgo.conf
 Overrides = { CFLAGS = "-O3", MAKEFLAGS = "-j8" }
+PkgbuildPatches = { "overrides/firefox-pkgrel-bump.patch", "https://raw.githubusercontent.com/ninetailedtori/paru/refs/heads/pkgbuild-patches/testdata/overrides/firefox-comment-addition.patch" }
 
 [override.group.lto-builds]
 Packages = mesa vulkan-radeon


### PR DESCRIPTION
This feature enables users to specify per-package overrides in `/etc/paru.conf`. These overrides can be specified for individual packages or for a group of package.

A per-package override may be defined as follows:

```
[override.package.firefox]
MakepkgConf = /etc/makepkg-pgo.conf
```

This configuration would utilize the specified makepkg config file for only the firefox package.

A group override may be defined as follows:

```
[override.group.lto-builds]
Packages = mesa vulkan-radeon
MakepkgConf = /etc/makepkg-lto.conf
Overrides = { MAKEFLAGS = "-j$(nproc)", CFLAGS = "-O3 -march=native" }
```

This configuration allows specifying multiple packages that will use the same custom config. Both package and group overrides allow specifying either or both `MakepkgConf`, which uses a custom config file, and `Overrides` which directly applies the specified env vars to the build.

Closes #901