### PR TITLE
feat: show package's AUR link on error

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -882,9 +882,11 @@ impl Installer {
                 Err(e) => {
                     if config.fail_fast {
                         self.failed.pop().unwrap();
+                        print_aur_link(config, &base);
                         return Err(e);
                     }
                     print_error(config.color.error, e);
+                    print_aur_link(config, &base);
                 }
             }
         }
@@ -1250,6 +1252,17 @@ impl Installer {
 
     fn upgrade_later(&self, config: &Config) -> bool {
         config.mode.repo() && config.chroot && (self.sysupgrade != 0 || self.refresh != 0)
+    }
+}
+
+fn print_aur_link(config: &Config, base: &Base) {
+    if let Base::Aur(aur_base) = base {
+        eprintln!(
+            "{} {}/packages/{}",
+            tr!("view on AUR:"),
+            config.aur_url.as_str().trim_end_matches('/'),
+            aur_base.package_base()
+        );
     }
 }
 


### PR DESCRIPTION
This PR adds a helpful link to the package's AUR page on error.

**before:**
```
...
==> ERROR: Integrity checks (sha256) differ in size from the source array.
error: failed to download sources for 'pince-0.5-1':
...
```

**after:**
```
...
==> ERROR: Integrity checks (sha256) differ in size from the source array.
error: failed to download sources for 'pince-0.5-1': 
view on AUR: https://aur.archlinux.org/packages/pince
...
```

