### PR TITLE
fix: exit(1) on EOF at interactive prompts

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -3,7 +3,7 @@ use crate::fmt::color_repo;
 use crate::util::{get_provider, NumberMenu};
 use crate::RaurHandle;
 
-use std::io::{stdin, stdout, BufRead, Write};
+use std::io::{stdout, Write};
 
 use aur_depends::{Flags, PkgbuildRepo, Resolver};
 use raur::Cache;
@@ -108,13 +108,9 @@ pub fn resolver<'a, 'b>(
             print!("{}", tr!("\n\nEnter a selection (default=all): "));
             let _ = stdout().lock().flush();
 
-            let stdin = stdin();
-            let mut stdin = stdin.lock();
             let mut input = String::new();
-
-            input.clear();
             if !no_confirm {
-                let _ = stdin.read_line(&mut input);
+                crate::util::read_line_or_exit(&mut input);
             }
 
             let menu = NumberMenu::new(input.trim());

--- a/src/util.rs
+++ b/src/util.rs
@@ -114,6 +114,17 @@ pub fn split_repo_aur_info<'a, T: AsTarg>(
     Ok((local, aur))
 }
 
+pub(crate) fn read_line_or_exit(input: &mut String) {
+    let stdin = stdin();
+    match stdin.lock().read_line(input) {
+        Ok(0) | Err(_) => {
+            println!();
+            std::process::exit(1);
+        }
+        Ok(_) => {}
+    }
+}
+
 pub fn ask(config: &Config, question: &str, default: bool) -> bool {
     let action = config.color.action;
     let bold = config.color.bold;
@@ -133,9 +144,8 @@ pub fn ask(config: &Config, question: &str, default: bool) -> bool {
         println!();
         return default;
     }
-    let stdin = stdin();
     let mut input = String::new();
-    let _ = stdin.read_line(&mut input);
+    read_line_or_exit(&mut input);
     let input = input.to_lowercase();
     let input = input.trim();
 
@@ -158,9 +168,8 @@ pub fn input(config: &Config, question: &str) -> String {
         println!();
         return "".into();
     }
-    let stdin = stdin();
     let mut input = String::new();
-    let _ = stdin.read_line(&mut input);
+    read_line_or_exit(&mut input);
     input
 }
 
@@ -302,9 +311,7 @@ pub fn get_provider(max: usize, no_confirm: bool) -> usize {
         input.clear();
 
         if !no_confirm {
-            let stdin = stdin();
-            let mut stdin = stdin.lock();
-            let _ = stdin.read_line(&mut input);
+            read_line_or_exit(&mut input);
         }
 
         let num = input.trim();


### PR DESCRIPTION
When stdin reaches EOF (e.g. Ctrl+D), read_line returns Ok(0) and leaves the buffer empty. The call sites discarded the return value, so empty input fell through to default-value branches which almost always mean "yes".

Add read_line_or_exit() helper that wraps stdin.read_line() and calls exit(1) on EOF or I/O error. Replace all raw read_line call sites with it.

Fixes #1518