### PR TITLE
fix: pass --ignorearch to makepkg --packagelist

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -2055,7 +2055,8 @@ fn parse_package_list(
     dir: &Path,
     pkgdest: Option<&str>,
 ) -> Result<(HashMap<String, String>, String)> {
-    let output = exec::makepkg_output_dest(config, dir, &["--packagelist"], pkgdest)?;
+    let output =
+        exec::makepkg_output_dest(config, dir, &["--packagelist", "--ignorearch"], pkgdest)?;
     let output = String::from_utf8(output.stdout).context("pkgdest is not utf8")?;
     let mut pkgdests = HashMap::new();
     let mut version = String::new();


### PR DESCRIPTION
pacman v7.1.0 (commit [2b281d71](https://gitlab.archlinux.org/pacman/pacman/-/commit/2b281d7124ee510d389d251bd60d4b9cee1e83ab)) removed the implicit IGNOREARCH=1 from makepkg's --packagelist handler, causing arch validation to fail before returning the package list on non-x86_64 systems.

Every other makepkg invocation in the build flow already passes -A; this was the only one missing it.

Closes #1526