### PR TITLE
docs(man): LocalRepo scope for AUR update checks

### DIFF
--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -251,6 +251,17 @@ Optionally a list of repos to use can be passed. By default paru will consider a
 local repos, building new packages into the first listed repo and upgrading the packages
 in other enabled repos.
 
+Foreign AUR packages installed outside any configured local repo (e.g. installed
+before LocalRepo was enabled, or via ad-hoc \fBmakepkg -si\fR) are not checked for
+updates by \fBparu -Syu\fR while LocalRepo is active. To check them, run
+\fBparu -Syu --nolocalrepo\fR, or bring them into the configured repo with:
+
+.nf
+.RS
+pacman -Qmq | paru -Ta - | paru -Sa -
+.RE
+.fi
+
 .TP
 .B Chroot [= path/to/chroot]
 Build packages in a chroot. This requires the LocalRepo option to be enabled.


### PR DESCRIPTION
paru -Syu with LocalRepo active silently skips foreign AUR packages installed outside any configured local repo, with no hint that --nolocalrepo or a rebuild-into-repo pipe would cover them. Document the scope and the recovery flows.