### PR TITLE
fix(devel): warn when ignoring devel package upgrades

### DIFF
--- a/src/devel.rs
+++ b/src/devel.rs
@@ -89,6 +89,12 @@ pub struct DevelInfo {
     pub info: HashMap<String, PkgInfo>,
 }
 
+#[derive(Default, Debug)]
+pub struct DevelUpgrades {
+    pub updates: Vec<String>,
+    pub ignored: Vec<String>,
+}
+
 fn ordered_map<S, T>(value: &HashMap<String, T>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -341,11 +347,12 @@ fn parse_url(source: &str) -> Option<(String, &'_ str, Option<&'_ str>)> {
     Some((remote, protocol, branch))
 }
 
-pub async fn possible_devel_updates(config: &Config) -> Result<Vec<String>> {
+pub async fn possible_devel_updates(config: &Config) -> Result<DevelUpgrades> {
     let devel_info = load_devel_info(config)?.unwrap_or_default();
     let db = config.alpm.localdb();
     let mut futures = Vec::new();
     let mut pkgbases: HashMap<&str, Vec<&alpm::Package>> = HashMap::new();
+    let mut ignored: Vec<String> = Vec::new();
 
     for pkg in db.pkgs().iter() {
         let name = pkg_base_or_name(pkg);
@@ -354,11 +361,10 @@ pub async fn possible_devel_updates(config: &Config) -> Result<Vec<String>> {
 
     'outer: for (pkg, repos) in &devel_info.info {
         if let Some(pkgs) = pkgbases.get(pkg.as_str()) {
-            if pkgs.iter().all(|p| p.should_ignore()) {
-                continue;
-            }
-
-            if pkgs.iter().all(|p| config.ignore_devel.is_match(p.name())) {
+            if pkgs.iter().all(|p| p.should_ignore())
+                || pkgs.iter().all(|p| config.ignore_devel.is_match(p.name()))
+            {
+                ignored.extend(pkgs.iter().map(|p| p.name().to_string()));
                 continue;
             }
         }
@@ -387,14 +393,14 @@ pub async fn possible_devel_updates(config: &Config) -> Result<Vec<String>> {
     updates.sort_unstable();
     updates.dedup();
 
-    Ok(updates)
+    Ok(DevelUpgrades { updates, ignored })
 }
 
 pub async fn filter_devel_updates(
     config: &Config,
     cache: &mut Cache,
     updates: &[String],
-) -> Result<Vec<Target>> {
+) -> Result<(Vec<Target>, Vec<String>)> {
     let mut pkgbases: HashMap<&str, Vec<&alpm::Package>> = HashMap::new();
     let mut aur = Vec::new();
     let mut custom = Vec::new();
@@ -427,24 +433,29 @@ pub async fn filter_devel_updates(
         .collect::<Vec<_>>();
 
     let mut updates = Vec::new();
+    let mut ignored: Vec<String> = Vec::new();
 
     if config.mode.aur() {
-        let aur = aur
-            .iter()
-            .flatten()
-            .filter(|p| !p.should_ignore())
-            .filter(|p| !config.ignore_devel.is_match(p.name()))
-            .map(|p| p.name().to_string())
-            .filter(|p| cache.contains(p.as_str()))
-            .map(|p| Target::new(Some(config.aur_namespace().to_string()), p));
-
-        updates.extend(aur);
+        for p in aur.iter().flatten() {
+            let name = p.name();
+            if !cache.contains(name) {
+                continue;
+            }
+            if p.should_ignore() || config.ignore_devel.is_match(name) {
+                ignored.push(name.to_string());
+            } else {
+                updates.push(Target::new(
+                    Some(config.aur_namespace().to_string()),
+                    name.to_string(),
+                ));
+            }
+        }
     }
     if config.mode.pkgbuild() {
         updates.extend(custom);
     }
 
-    Ok(updates)
+    Ok((updates, ignored))
 }
 
 pub async fn pkg_has_update<'pkg>(

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::config::{Config, Mode};
-use crate::devel::{filter_devel_updates, possible_devel_updates};
+use crate::devel::{filter_devel_updates, possible_devel_updates, DevelUpgrades};
 use crate::exec;
 use crate::util::split_repo_aur_pkgs;
 
@@ -89,12 +89,11 @@ pub async fn print_upgrade_list(config: &mut Config) -> Result<i32> {
         }
 
         if config.mode.aur() {
-            async fn devel_up(config: &Config) -> Result<Vec<String>> {
+            async fn devel_up(config: &Config) -> Result<DevelUpgrades> {
                 if config.devel {
-                    let updates = possible_devel_updates(config).await?;
-                    Ok(updates)
+                    possible_devel_updates(config).await
                 } else {
-                    Ok(Vec::new())
+                    Ok(DevelUpgrades::default())
                 }
             }
 
@@ -104,7 +103,8 @@ pub async fn print_upgrade_list(config: &mut Config) -> Result<i32> {
             }
 
             let (_, devel) = try_join!(aur_up(config, &mut cache, &aur), devel_up(config))?;
-            let devel = filter_devel_updates(config, &mut cache, &devel).await?;
+            let (devel, _ignored) =
+                filter_devel_updates(config, &mut cache, &devel.updates).await?;
 
             for target in aur {
                 let local_pkg = db.pkg(target).unwrap();

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,5 +1,5 @@
 use crate::config::{Config, LocalRepos};
-use crate::devel::{filter_devel_updates, possible_devel_updates};
+use crate::devel::{filter_devel_updates, possible_devel_updates, DevelUpgrades};
 use crate::fmt::color_repo;
 use crate::util::{input, NumberMenu};
 use crate::{repo, RaurHandle};
@@ -152,9 +152,9 @@ async fn get_resolver_upgrades<'a, 'b>(
     }
 }
 
-async fn get_devel_upgrades(config: &Config, print: bool) -> Result<Vec<String>> {
+async fn get_devel_upgrades(config: &Config, print: bool) -> Result<DevelUpgrades> {
     if !config.devel || (!config.mode.aur() && !config.mode.pkgbuild()) {
-        return Ok(Vec::new());
+        return Ok(DevelUpgrades::default());
     }
 
     let c = config.color;
@@ -173,7 +173,7 @@ pub async fn net_upgrades<'res>(
     config: &'_ Config,
     resolver: &mut Resolver<'res, '_, RaurHandle>,
     print: bool,
-) -> Result<(Updates<'res>, Vec<String>)> {
+) -> Result<(Updates<'res>, DevelUpgrades)> {
     try_join!(
         get_resolver_upgrades(config, resolver, print),
         get_devel_upgrades(config, print)
@@ -184,7 +184,7 @@ pub async fn get_upgrades<'a, 'b>(
     config: &Config,
     resolver: &mut Resolver<'a, 'b, RaurHandle>,
 ) -> Result<Upgrades> {
-    let (upgrades, devel_upgrades) = net_upgrades(config, resolver, true).await?;
+    let (upgrades, devel) = net_upgrades(config, resolver, true).await?;
     let (syncdbs, aurdbs) = repo::repo_aur_dbs(config);
 
     for pkg in upgrades.aur_ignored {
@@ -215,8 +215,30 @@ pub async fn get_upgrades<'a, 'b>(
 
     let mut aur_upgrades = upgrades.aur_updates;
     let pkgbuild_upgrades = upgrades.pkgbuild_updates;
-    let mut devel_upgrades =
-        filter_devel_updates(config, resolver.get_cache_mut(), &devel_upgrades).await?;
+    let (mut devel_upgrades, devel_extra_ignored) =
+        filter_devel_updates(config, resolver.get_cache_mut(), &devel.updates).await?;
+
+    let mut devel_ignored = devel.ignored;
+    devel_ignored.extend(devel_extra_ignored);
+    devel_ignored.sort_unstable();
+    devel_ignored.dedup();
+
+    let localdb = config.alpm.localdb();
+    for name in &devel_ignored {
+        let Ok(pkg) = localdb.pkg(name.as_str()) else {
+            continue;
+        };
+        eprintln!(
+            "{} {}",
+            config.color.warning.paint(tr!("warning:")),
+            tr!(
+                "{pkg}: ignoring package upgrade ({old} => {new})",
+                pkg = name.as_str(),
+                old = pkg.version(),
+                new = "latest-commit",
+            )
+        );
+    }
 
     let repo_upgrades = if config.mode.repo() && config.combined_upgrade {
         repo_upgrades(config)?

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -199,3 +199,27 @@ async fn devel() {
     let a = db.pkg("devel").unwrap();
     assert_eq!(a.version().as_str(), "2-1");
 }
+
+#[tokio::test]
+async fn devel_ignore() {
+    let (tmp, ret) = run(&["-Sua", "--devel", "--ignore=devel"]).await.unwrap();
+    assert_eq!(ret, 0);
+    let alpm = alpm(&tmp).unwrap();
+
+    let db = alpm.localdb();
+    let a = db.pkg("devel").unwrap();
+    assert_eq!(a.version().as_str(), "1-1");
+}
+
+#[tokio::test]
+async fn devel_ignoredevel_glob() {
+    let (tmp, ret) = run(&["-Sua", "--devel", "--ignoredevel=dev*"])
+        .await
+        .unwrap();
+    assert_eq!(ret, 0);
+    let alpm = alpm(&tmp).unwrap();
+
+    let db = alpm.localdb();
+    let a = db.pkg("devel").unwrap();
+    assert_eq!(a.version().as_str(), "1-1");
+}


### PR DESCRIPTION
Devel upgrade detection silently dropped packages matching `IgnorePkg` or `IgnoreDevel`, unlike the regular AUR path which prints a warning. 

this PR threads the ignored list through `possible_devel_updates` and `filter_devel_updates` to `the get_upgrades` print site.

Closes: #1532
