### PR TITLE
Fix -B --noconfirm conflict check

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -1380,26 +1380,54 @@ fn check_actions(
         );
     }
 
+    let build_only_targets = if install_targets {
+        None
+    } else {
+        let mut build_only_targets = HashSet::new();
+
+        for base in &actions.build {
+            match base {
+                Base::Aur(base) => build_only_targets.extend(
+                    base.pkgs
+                        .iter()
+                        .filter(|pkg| pkg.target)
+                        .map(|pkg| pkg.pkg.name.clone()),
+                ),
+                Base::Pkgbuild(base) => build_only_targets.extend(
+                    base.pkgs
+                        .iter()
+                        .filter(|pkg| pkg.target)
+                        .map(|pkg| pkg.pkg.pkgname.clone()),
+                ),
+            }
+        }
+
+        Some(build_only_targets)
+    };
+
+    let filter_build_only_targets = |conflicts: &mut Vec<Conflict>| {
+        if let Some(build_only_targets) = build_only_targets.as_ref() {
+            conflicts.retain_mut(|conflict| {
+                if build_only_targets.contains(&conflict.pkg) {
+                    return false;
+                }
+
+                conflict
+                    .conflicting
+                    .retain(|pkg| !build_only_targets.contains(&pkg.pkg));
+                !conflict.conflicting.is_empty()
+            });
+        }
+    };
+
     let conflicts = if !config.chroot || install_targets {
         println!(
             "{} {}",
             c.action.paint("::"),
             c.bold.paint(tr!("Calculating conflicts..."))
         );
-        // Hack to ignore conflicts on -B
-        // Only ignores conflicts for the last package instead of all targets
-        // As in theory one target could depend on another and thus must be installed
         let mut conflicts = actions.calculate_conflicts(!config.chroot);
-        if !install_targets {
-            if let Some(build) = actions.build.last() {
-                let pkgs = build.packages().map(|s| s.to_string()).collect::<Vec<_>>();
-                conflicts.retain(|c| {
-                    !c.conflicting
-                        .iter()
-                        .all(|conflicting| pkgs.contains(&conflicting.pkg))
-                });
-            }
-        }
+        filter_build_only_targets(&mut conflicts);
         conflicts
     } else {
         Vec::new()
@@ -1409,7 +1437,8 @@ fn check_actions(
         c.action.paint("::"),
         c.bold.paint(tr!("Calculating inner conflicts..."))
     );
-    let inner_conflicts = actions.calculate_inner_conflicts(!config.chroot);
+    let mut inner_conflicts = actions.calculate_inner_conflicts(!config.chroot);
+    filter_build_only_targets(&mut inner_conflicts);
 
     if !conflicts.is_empty() || !inner_conflicts.is_empty() {
         eprintln!();

--- a/testdata/clone/devel-bin/.SRCINFO
+++ b/testdata/clone/devel-bin/.SRCINFO
@@ -1,0 +1,6 @@
+pkgbase = devel-bin
+	pkgver = 1
+	pkgrel = 1
+	arch = any
+
+pkgname = devel-bin

--- a/testdata/clone/devel-bin/PKGBUILD
+++ b/testdata/clone/devel-bin/PKGBUILD
@@ -1,0 +1,5 @@
+pkgname=devel-bin
+pkgver=1
+pkgrel=1
+arch=(any)
+conflicts=(devel)

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -199,3 +199,9 @@ async fn devel() {
     let a = db.pkg("devel").unwrap();
     assert_eq!(a.version().as_str(), "2-1");
 }
+
+#[tokio::test]
+async fn build_only_conflict_with_installed_pkg() {
+    let (_, ret) = run(&["-B", "testdata/clone/devel-bin"]).await.unwrap();
+    assert_eq!(ret, 0);
+}


### PR DESCRIPTION
As reported in https://github.com/Morganamilo/paru/issues/1376, trying to build a package that would conflict with any installed packages currently works interactively, but not with `--noconfirm`.

https://github.com/Morganamilo/paru/commit/77992030587b69b581dba345749ec378f00d18c8 was trying to fix the problem, but the issue persists on the latest master.

To reproduce, an easy way is trying to build one of paru/paru-bin/paru-git (whichever is not currently installed on the system, or all 3).

Example if `paru` is already installed, trying to build `paru-bin`:
```
cargo run -- -G paru-bin && cargo run -- -B --noconfirm paru-bin
```

Currently on the latest master, this outputs:

```
:: Generating .SRCINFO for ./paru-bin...
:: Resolving dependencies...
:: Calculating conflicts...
:: Calculating inner conflicts...

:: Conflicts found:
    paru-bin: paru

:: Conflicting packages will have to be confirmed manually
error: can not install conflicting packages with --noconfirm
```

Another reproduction example: the `eternalterminal` package. It's a split package with 3 packages: a client, a server, and a package that includes both (unfortunately not a virtual package that depends on both the client and the server). Trying to build it produces internal conflicts with the current master branch, but works with this PR.

```
cargo run -- -G eternalterminal && cargo run -- -B --noconfirm eternalterminal
```

In this branch, this properly builds the package.

This now:
* Properly accounts for all packages being built, not just the latest one (for split packages where we build multiple packages)
* Apply the filter on inner conflicts as well, which is what was being triggered on no-confirm.