### PR TITLE
fix(bat): let BatFlags override default style

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -662,7 +662,8 @@ pub async fn show_pkgbuilds(config: &mut Config) -> Result<i32> {
 fn pipe_bat(config: &Config, pkgbuild: &[u8]) -> Result<()> {
     let mut command = Command::new(&config.bat_bin);
     command
-        .arg("-pp")
+        .arg("--paging=never")
+        .arg("--style=plain")
         .arg("--color=always")
         .arg("-lPKGBUILD")
         .args(&config.bat_flags)

--- a/src/install.rs
+++ b/src/install.rs
@@ -1658,7 +1658,8 @@ fn print_dir(
             );
             if bat {
                 let mut cmd = Command::new(&config.bat_bin);
-                cmd.arg("-pp")
+                cmd.arg("--paging=never")
+                    .arg("--style=plain")
                     .arg("--color=always")
                     .arg(file.path())
                     .args(&config.bat_flags);


### PR DESCRIPTION
this change replaces `-pp` with the explicit pair `--paging=never --style=plain` so a later `--style=` from `BatFlags` can override `--style=plain` while paging stays off                                                                                               

reported in #1539. the BatFlags override contract has been mentioned back in #143 (`--batflags --paging=always`), #77 (--batflags --theme=Dracula), #500 ("Set BatFlags"). d36cbe8 ("bat: disable pager") introduced `-pp` purely to disable bat's pager; the `--style=plain` side effect of the shorthand does seem to be an intentional lock-in