### PR TITLE
fix: only route -G through ABS for official Arch repos

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -519,9 +519,13 @@ fn split_target_pkgbuilds<'a, T: AsTarg>(
 
     for targ in targets {
         let targ = targ.as_targ();
-        if config.mode.repo() && db.find_target(targ).is_ok() {
-            local.push(targ);
-            continue;
+        if config.mode.repo() {
+            if let Ok(pkg) = db.find_target(targ) {
+                if is_arch_repo(pkg.db().unwrap().name()) {
+                    local.push(targ);
+                    continue;
+                }
+            }
         }
 
         if config.mode.pkgbuild() {


### PR DESCRIPTION
when a target is present in both the AUR and a custom pacman syncdb (e.g. a local prebuilt aur cache repo), `paru -G` routed the target through `pkgctl repo clone` against gitlab.archlinux.org, which then prompted for credentials on a non-existent gl repo instead of falling back to the aur

restore the pre-existing gate on `is_arch_repo` so only targets from core/extra/multilib/testing are treated as ABS

this is also the documented behavior in the man page:

> Downloads PKGBUILDs from the ABS or AUR. **The ABS can only be used for Arch Linux repositories.**

Closes: #1541