### PR TITLE
docs(man): cross-reference IgnoreDevelSource from --devel

### DIFF
--- a/man/paru.8
+++ b/man/paru.8
@@ -530,6 +530,12 @@ checked almost instantly and not require the original PKGBUILD to be downloaded.
 The slower pacaur-like devel checks can be implemented manually by piping
 a list of packages into paru (see \fBexamples\fR).
 
+Some packages track git sources whose HEAD moves often without changing the
+resulting package version. These will appear as devel updates on every run even
+when rebuilding produces an identical package. See \fBIgnoreDevel\fR and
+\fBIgnoreDevelSource\fR in \fBparu.conf\fR(5) to opt such packages or sources
+out of devel checking.
+
 .TP
 .B \-\-ignoredevel
 Like --ignore but for devel upgrades. Packages matching this will not be tried for a


### PR DESCRIPTION
## Summary

The `--devel` section in `paru(8)` explains the `git ls-remote` check but never names the failure modes it has: PKGBUILDs that `git checkout` a different ref in `prepare()`, or that list secondary git sources which don't drive `pkgver`, will appear as devel updates on every run even when the resulting package is identical.

Two config knobs already exist for exactly this case (`IgnoreDevel`, `IgnoreDevelSource` in `paru.conf(5)`), but they're discoverable only by reading the config man page front to back. Users repeatedly reach for a bug report instead.

This adds a single paragraph under `--devel` that names the failure mode and points at both options.
