### PR TITLE
fix(completion): handle NUL-separated package candidates

### DIFF
--- a/completions/bash
+++ b/completions/bash
@@ -41,7 +41,7 @@ _pacman_pkg() {
 
 _paru_pkg() {
   [ -z "$cur" ] && _pacman_pkg Slq && return
-  _arch_compgen "$(paru -Pc)"
+  _arch_compgen "$(paru -Pc | tr '\000' '\n')"
 }
 
 _pacman_repo_list() {


### PR DESCRIPTION
Fix Bash completion warning caused by NUL-separated package candidates from `paru -Pc`.

## Problem

When completing package names with Bash completion, for example:

```bash
paru -S gpu-screen-reco<Tab>
````

Bash prints:

```text
bash: warning: command substitution: ignored null byte in input
```

The warning comes from `_paru_pkg()`:

```bash
_arch_compgen "$(paru -Pc)"
```

`paru -Pc` emits NUL bytes. Bash command substitution cannot preserve NUL bytes, so Bash drops them and prints the warning.

On my system:

```bash
$ paru -Pc | LC_ALL=C tr -cd '\000' | wc -c
1734
```

## Fix

Convert NUL bytes to newlines before passing the output into `_arch_compgen`:

```bash
_arch_compgen "$(paru -Pc | tr '\000' '\n')"
```

This preserves candidate separation and avoids the Bash warning.

## Testing

Confirmed that `paru -Pc` emits NUL bytes:

```bash
$ paru -Pc | LC_ALL=C tr -cd '\000' | wc -c
1734
```

Confirmed that converting NUL bytes to newlines removes them:

```bash
$ paru -Pc | tr '\000' '\n' | LC_ALL=C tr -cd '\000' | wc -c
0
```

After applying the patch, Bash completion works without the warning:

```bash
paru -S gpu-screen-reco<Tab>
```

Expected candidates are shown:

```bash
$ paru -S gpu-screen-recorder
gpu-screen-recorder               gpu-screen-recorder-notification  gpu-screen-recorder-ui
```