### PR TITLE
Add AUR download rate limiting and retry options

### DIFF
--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -223,6 +223,29 @@ cache to be refreshed every time, while setting this to -1 will cause the cache
 to never be refreshed. Defaults to 7.
 
 .TP
+.B AurMaxParallel = N
+Maximum number of AUR packages to download (git clone/fetch) concurrently.
+Lowering this is the main way to avoid AUR rate limiting. Defaults to 20.
+
+.TP
+.B AurDownloadDelay = N
+Minimum delay, in seconds, between starting two consecutive AUR downloads.
+This is a global throttle applied regardless of how many downloads run in
+parallel. Defaults to 0 (disabled).
+
+.TP
+.B AurMaxRetries = N
+How many times to retry an AUR download that failed with a transient network
+error (connection closed/reset, timeouts, HTTP 429/5xx, DNS failures, ...).
+Non-transient errors (missing package, auth) are not retried. Defaults to 3.
+
+.TP
+.B AurRetryDelay = N
+Base delay, in seconds, for the exponential backoff between download retries.
+Retry number n waits AurRetryDelay * 2^n seconds, capped at 30 seconds.
+Defaults to 2.
+
+.TP
 .B PacmanConf = path/to/pacman.conf
 The pacman config file to use.
 

--- a/paru.conf
+++ b/paru.conf
@@ -24,6 +24,12 @@ DevelSuffixes = -git -cvs -svn -bzr -darcs -always -hg -fossil
 #UpgradeMenu
 #NewsOnUpgrade
 
+# AUR download rate limiting / retry (see paru.conf(5))
+#AurMaxParallel = 20
+#AurDownloadDelay = 0
+#AurMaxRetries = 3
+#AurRetryDelay = 2
+
 #LocalRepo
 #Chroot
 #Sign

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -211,6 +211,26 @@ impl Config {
                     .parse()
                     .map_err(|_| anyhow!("option {} must be a number", arg))?
             }
+            Arg::Long("aurmaxparallel") => {
+                self.aur_max_parallel = value?
+                    .parse()
+                    .map_err(|_| anyhow!("option {} must be a number", arg))?
+            }
+            Arg::Long("aurdownloaddelay") => {
+                self.aur_download_delay = value?
+                    .parse()
+                    .map_err(|_| anyhow!("option {} must be a number", arg))?
+            }
+            Arg::Long("aurmaxretries") => {
+                self.aur_max_retries = value?
+                    .parse()
+                    .map_err(|_| anyhow!("option {} must be a number", arg))?
+            }
+            Arg::Long("aurretrydelay") => {
+                self.aur_retry_delay = value?
+                    .parse()
+                    .map_err(|_| anyhow!("option {} must be a number", arg))?
+            }
             Arg::Long("sortby") => self.sort_by = ConfigEnum::from_str(argkey, value?)?,
             Arg::Long("searchby") => self.search_by = ConfigEnum::from_str(argkey, value?)?,
             Arg::Long("limit") => self.limit = value?.parse()?,
@@ -417,6 +437,10 @@ fn takes_value(arg: Arg) -> TakesValue {
         Arg::Long("chrootpkgs") => TakesValue::Required,
         Arg::Long("rootchrootpkgs") => TakesValue::Required,
         Arg::Long("completioninterval") => TakesValue::Required,
+        Arg::Long("aurmaxparallel") => TakesValue::Required,
+        Arg::Long("aurdownloaddelay") => TakesValue::Required,
+        Arg::Long("aurmaxretries") => TakesValue::Required,
+        Arg::Long("aurretrydelay") => TakesValue::Required,
         Arg::Long("sortby") => TakesValue::Required,
         Arg::Long("searchby") => TakesValue::Required,
         Arg::Long("limit") => TakesValue::Required,

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ use std::fs::{remove_file, OpenOptions};
 use std::io::{stderr, stdin, stdout, BufRead, IsTerminal};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::time::Duration;
 
 use alpm::{
     AnyDownloadEvent, AnyQuestion, Depend, DownloadEvent, DownloadResult, LogLevel, Question,
@@ -441,6 +442,19 @@ pub struct Config {
     #[default = 7]
     pub completion_interval: u64,
 
+    /// Max number of AUR packages to download (git clone/fetch) concurrently.
+    #[default = 20]
+    pub aur_max_parallel: usize,
+    /// Minimum delay in seconds between two AUR downloads (0 = disabled).
+    pub aur_download_delay: u64,
+    /// How many times to retry an AUR download that failed with a transient
+    /// network error.
+    #[default = 3]
+    pub aur_max_retries: usize,
+    /// Base delay in seconds for exponential backoff between download retries.
+    #[default = 2]
+    pub aur_retry_delay: u64,
+
     pub help: bool,
     pub version: bool,
 
@@ -662,6 +676,11 @@ impl Config {
         self.globals.as_str()
     }
 
+    /// AUR download throttle delay, or `None` when disabled (0).
+    pub fn aur_download_delay(&self) -> Option<Duration> {
+        (self.aur_download_delay > 0).then(|| Duration::from_secs(self.aur_download_delay))
+    }
+
     pub fn parse_args<S: AsRef<str>, I: IntoIterator<Item = S>>(&mut self, iter: I) -> Result<()> {
         let iter = iter.into_iter();
         let mut iter = iter.peekable();
@@ -762,6 +781,10 @@ impl Config {
             clone_dir: self.build_dir.clone(),
             diff_dir: self.cache_dir.join("diff"),
             aur_url: aur_url.clone(),
+            parallel: self.aur_max_parallel,
+            download_delay: self.aur_download_delay(),
+            max_retries: self.aur_max_retries,
+            retry_delay: Duration::from_secs(self.aur_retry_delay),
         };
 
         self.pkgbuild_repos.fetch = aur_fetch::Fetch {
@@ -770,6 +793,10 @@ impl Config {
             clone_dir: self.build_dir.join("repo"),
             diff_dir: self.cache_dir.join("repo/diff"),
             aur_url,
+            parallel: self.aur_max_parallel,
+            download_delay: self.aur_download_delay(),
+            max_retries: self.aur_max_retries,
+            retry_delay: Duration::from_secs(self.aur_retry_delay),
         };
 
         for repo in &mut self.pkgbuild_repos.repos {
@@ -1116,6 +1143,10 @@ then initialise it with:
             "SearchBy" => self.search_by = ConfigEnum::from_str(key, value?.as_str())?,
             "Limit" => self.limit = value?.parse()?,
             "CompletionInterval" => self.completion_interval = value?.parse()?,
+            "AurMaxParallel" => self.aur_max_parallel = value?.parse()?,
+            "AurDownloadDelay" => self.aur_download_delay = value?.parse()?,
+            "AurMaxRetries" => self.aur_max_retries = value?.parse()?,
+            "AurRetryDelay" => self.aur_retry_delay = value?.parse()?,
             "PacmanConf" => self.pacman_conf = Some(value?),
             "MakepkgConf" => self.makepkg_conf = Some(value?),
             "DevelSuffixes" => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,10 @@ async fn run2<S: AsRef<str>>(config: &mut Config, args: &[S]) -> Result<i32> {
         clone_dir: config.build_dir.clone(),
         diff_dir: config.cache_dir.join("diff"),
         aur_url,
+        parallel: config.aur_max_parallel,
+        download_delay: config.aur_download_delay(),
+        max_retries: config.aur_max_retries,
+        retry_delay: std::time::Duration::from_secs(config.aur_retry_delay),
     };
 
     let mut fetch = config.fetch.clone();


### PR DESCRIPTION
Add four new config options to mitigate AUR rate limiting and
transient network failures during git clone/fetch:

- AurMaxParallel: cap concurrent AUR downloads (default 20)
- AurDownloadDelay: global throttle between downloads (default 0)
- AurMaxRetries: retries on transient errors (default 3)
- AurRetryDelay: base delay for exponential backoff (default 2)

Each option is available as a CLI flag and in paru.conf, and is
documented in paru.conf(5).

This commit needs associated changes in aur_fetch.rs
