### PR TITLE
feat: add minimum release age gate for AUR packages

### DIFF
--- a/man/paru.8
+++ b/man/paru.8
@@ -443,6 +443,23 @@ cache to be refreshed every time, while setting this to -1 will cause the cache
 to never be refreshed. Defaults to 7.
 
 .TP
+.B \-\-minimumreleaseage <duration>
+Refuse to install, upgrade or list AUR packages published more recently than
+this. The duration is an integer with an optional unit suffix (s, m, h, d, w);
+a bare number means days. Applies to dependencies too; devel packages are
+exempt. See
+.B MinimumReleaseAge
+in paru.conf(5).
+
+.TP
+.B \-\-nominimumreleaseage
+Disable the minimum release age check for this run.
+
+.TP
+.B \-\-minimumreleaseageexclude <packages>
+Packages exempt from the minimum release age check. Accepts glob patterns.
+
+.TP
 .B \-\-sortby <votes|popularity|id|baseid|name|base|submitted|modified>
 Sort AUR results by a specific field during search. Defaults to votes.
 

--- a/man/paru.conf.5
+++ b/man/paru.conf.5
@@ -241,6 +241,39 @@ set.
 Don't warn when these packages are not in the aur, out of date, or orphaned.
 
 .TP
+.B MinimumReleaseAge = Duration
+Refuse to install or upgrade AUR packages whose latest version was published
+more recently than this. The value is an integer with an optional unit suffix:
+.B s
+(seconds),
+.B m
+(minutes),
+.B h
+(hours),
+.B d
+(days) or
+.B w
+(weeks). A bare number is interpreted as days. This mitigates supply-chain
+attacks, since most AUR hijacks are caught and reverted within a few days.
+
+The check applies to the whole resolved transaction, including dependencies. If
+any package is too new, paru aborts and lists the offending packages. Devel
+(\fB-git\fR and similar) packages are exempt, as they are tracked by upstream
+commit rather than AUR publish time. Note this exemption is keyed on the package
+name suffix (see
+.BR DevelSuffixes ),
+so a package merely named with such a suffix is exempt regardless of how it is
+built. Disabled by default. Pass
+.B \-\-nominimumreleaseage
+to override for a single run.
+
+.TP
+.B MinimumReleaseAgeExclude = Packages...
+Packages exempt from
+.BR MinimumReleaseAge .
+Accepts glob patterns.
+
+.TP
 .B LocalRepo [= Repos...]
 Use a local repo to build and upgrade AUR packages.
 

--- a/paru.conf
+++ b/paru.conf
@@ -23,6 +23,8 @@ DevelSuffixes = -git -cvs -svn -bzr -darcs -always -hg -fossil
 #CleanAfter
 #UpgradeMenu
 #NewsOnUpgrade
+#MinimumReleaseAge = 3d
+#MinimumReleaseAgeExclude
 
 #LocalRepo
 #Chroot

--- a/po/paru.pot
+++ b/po/paru.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: paru  2.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Morganamilo/paru\n"
-"POT-Creation-Date: 2026-01-08 17:40+0000\n"
+"POT-Creation-Date: 2026-06-16 22:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -58,15 +58,15 @@ msgstr ""
 msgid "option {} expects a value"
 msgstr ""
 
-#: src/command_line.rs:165 src/command_line.rs:382
+#: src/command_line.rs:165 src/command_line.rs:391
 msgid "option {} does not allow a value"
 msgstr ""
 
-#: src/command_line.rs:373
+#: src/command_line.rs:382
 msgid "unknown option --{}"
 msgstr ""
 
-#: src/command_line.rs:376
+#: src/command_line.rs:385
 msgid "unknown option -{}"
 msgstr ""
 
@@ -90,88 +90,96 @@ msgstr ""
 msgid "unknown mode {}"
 msgstr ""
 
-#: src/config.rs:564
+#: src/config.rs:570
 msgid "section can not be called {}"
 msgstr ""
 
-#: src/config.rs:581
+#: src/config.rs:604
 msgid "failed to find cache directory"
 msgstr ""
 
-#: src/config.rs:584
+#: src/config.rs:607
 msgid "failed to find config directory"
 msgstr ""
 
-#: src/config.rs:588
+#: src/config.rs:611
 msgid "failed to find state directory"
 msgstr ""
 
-#: src/config.rs:635
+#: src/config.rs:658
 msgid "config file '{}' does not exist"
 msgstr ""
 
-#: src/config.rs:684
+#: src/config.rs:707
 msgid "only one operation may be used at a time"
 msgstr ""
 
-#: src/config.rs:795
+#: src/config.rs:818
 msgid "no local repo named {}"
 msgstr ""
 
-#: src/config.rs:821
+#: src/config.rs:844
 msgid "can not find local repo '{}' in pacman.conf"
 msgstr ""
 
-#: src/config.rs:866
+#: src/config.rs:890
 msgid "failed to initialize alpm: root={} dbpath={}"
 msgstr ""
 
-#: src/config.rs:941 src/config.rs:1102
+#: src/config.rs:965 src/config.rs:1126
 msgid "value can not be empty for key '{}'"
 msgstr ""
 
-#: src/config.rs:957
+#: src/config.rs:981
 msgid "key '{}' does not belong to a section"
 msgstr ""
 
-#: src/config.rs:971 src/config.rs:988 src/config.rs:990 src/config.rs:1005
+#: src/config.rs:995 src/config.rs:1012 src/config.rs:1014 src/config.rs:1029
 msgid "key can not be empty"
 msgstr ""
 
-#: src/config.rs:981
+#: src/config.rs:1005
 msgid "error: unknown option '{}' in repo"
 msgstr ""
 
-#: src/config.rs:991
+#: src/config.rs:1015
 msgid "key can not contain null bytes"
 msgstr ""
 
-#: src/config.rs:994
+#: src/config.rs:1018
 msgid "value can not contain null bytes"
 msgstr ""
 
-#: src/config.rs:1030
+#: src/config.rs:1054
 msgid "error: unknown option '{}' in section [bin]"
 msgstr ""
 
-#: src/config.rs:1150
+#: src/config.rs:1180
 msgid "error: unknown option '{}' in section [options]"
 msgstr ""
 
-#: src/config.rs:1155
+#: src/config.rs:1185
 msgid "option '{}' does not take a value"
 msgstr ""
 
-#: src/config.rs:1187 src/resolver.rs:136
+#: src/config.rs:1217 src/resolver.rs:132
 msgid "There are {n} providers available for {pkg}:"
 msgstr ""
 
-#: src/config.rs:1201 src/info.rs:85 src/info.rs:190 src/info.rs:224 src/resolver.rs:95 src/resolver.rs:144
+#: src/config.rs:1231 src/info.rs:85 src/info.rs:190 src/info.rs:224 src/resolver.rs:95 src/resolver.rs:140
 msgid "Repository"
 msgstr ""
 
-#: src/config.rs:1227
+#: src/config.rs:1257
 msgid "  failed to sync {}"
+msgstr ""
+
+#: src/config.rs:1274 src/config.rs:1280
+msgid "invalid release age '{}'"
+msgstr ""
+
+#: src/config.rs:1284
+msgid "release age '{}' is too large"
 msgstr ""
 
 #: src/devel.rs:136 src/download.rs:207
@@ -262,7 +270,7 @@ msgstr ""
 msgid "Pacman is currently in use, please wait..."
 msgstr ""
 
-#: src/fmt.rs:24 src/info.rs:275 src/search.rs:293 src/search.rs:350
+#: src/fmt.rs:24 src/info.rs:275 src/search.rs:299 src/search.rs:356
 msgid "None"
 msgstr ""
 
@@ -762,7 +770,7 @@ msgstr ""
 msgid "could not get news"
 msgstr ""
 
-#: src/install.rs:172 src/install.rs:1127
+#: src/install.rs:172 src/install.rs:1128
 msgid "Proceed with installation?"
 msgstr ""
 
@@ -814,7 +822,7 @@ msgstr ""
 msgid "no targets specified (use -h for help)"
 msgstr ""
 
-#: src/install.rs:1008 src/install.rs:1097 src/search.rs:450 src/search.rs:476 src/lib.rs:304
+#: src/install.rs:1008 src/install.rs:1098 src/search.rs:456 src/search.rs:482 src/lib.rs:304
 msgid " there is nothing to do"
 msgstr ""
 
@@ -830,108 +838,144 @@ msgstr ""
 msgid "--downloadonly can't be used for AUR packages"
 msgstr ""
 
-#: src/install.rs:1113
+#: src/install.rs:1114
 msgid "Remove make dependencies after install?"
 msgstr ""
 
-#: src/install.rs:1124
+#: src/install.rs:1125
 msgid "Proceed to review?"
 msgstr ""
 
-#: src/install.rs:1177
+#: src/install.rs:1178
 msgid "no architecture"
 msgstr ""
 
-#: src/install.rs:1191
+#: src/install.rs:1192
 msgid "The following packages are not compatible with your architecture:"
 msgstr ""
 
-#: src/install.rs:1205
+#: src/install.rs:1206
 msgid "Would you like to try build them anyway?"
 msgstr ""
 
-#: src/install.rs:1349
+#: src/install.rs:1338
+msgid "{n} day"
+msgid_plural "{n} days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/install.rs:1341
+msgid "{n} hour"
+msgid_plural "{n} hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/install.rs:1344
+msgid "{n} minute"
+msgid_plural "{n} minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/install.rs:1346
+msgid "{n} second"
+msgid_plural "{n} seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/install.rs:1374
+msgid "updated {} ago"
+msgstr ""
+
+#: src/install.rs:1381
+msgid "the following AUR packages are newer than the minimum release age of {}: {}"
+msgstr ""
+
+#: src/install.rs:1385
+msgid "pass --nominimumreleaseage with your operation to override (e.g. paru -Syu --nominimumreleaseage), or add a package to MinimumReleaseAgeExclude"
+msgstr ""
+
+#: src/install.rs:1405
 msgid "duplicate packages: {}"
 msgstr ""
 
-#: src/install.rs:1353
+#: src/install.rs:1409
 msgid "could not find all required packages:"
 msgstr ""
 
-#: src/install.rs:1365
+#: src/install.rs:1421
 msgid "\n"
 "    {missing} (wanted by: {stack})"
 msgstr ""
 
-#: src/install.rs:1379 src/install.rs:2122
+#: src/install.rs:1435 src/install.rs:2178
 msgid "{}-{} is up to date -- skipping"
 msgstr ""
 
-#: src/install.rs:1387
+#: src/install.rs:1443
 msgid "Calculating conflicts..."
 msgstr ""
 
-#: src/install.rs:1410
+#: src/install.rs:1466
 msgid "Calculating inner conflicts..."
 msgstr ""
 
-#: src/install.rs:1422
+#: src/install.rs:1478
 msgid "Inner conflicts found:"
 msgstr ""
 
-#: src/install.rs:1444
+#: src/install.rs:1500
 msgid "Conflicts found:"
 msgstr ""
 
-#: src/install.rs:1467
+#: src/install.rs:1523
 msgid "Conflicting packages will have to be confirmed manually"
 msgstr ""
 
-#: src/install.rs:1471
+#: src/install.rs:1527
 msgid "can not install conflicting packages with --noconfirm"
 msgstr ""
 
-#: src/install.rs:1599
+#: src/install.rs:1655
 msgid "failed to execute file manager: {}"
 msgstr ""
 
-#: src/install.rs:1602
+#: src/install.rs:1658
 msgid "file manager '{}' did not execute successfully"
 msgstr ""
 
-#: src/install.rs:1620
+#: src/install.rs:1676
 msgid "failed to read dir: {}"
 msgstr ""
 
-#: src/install.rs:1677
+#: src/install.rs:1733
 msgid "failed to open: {}"
 msgstr ""
 
-#: src/install.rs:1697
+#: src/install.rs:1753
 msgid "binary file: {}"
 msgstr ""
 
-#: src/install.rs:1719 src/install.rs:1790
+#: src/install.rs:1775 src/install.rs:1846
 msgid "Accept changes?"
 msgstr ""
 
-#: src/install.rs:1759
+#: src/install.rs:1815
 msgid "Paging with less. Press 'q' to quit or 'h' for help."
 msgstr ""
 
-#: src/install.rs:1794
+#: src/install.rs:1850
 msgid " nothing new to review"
 msgstr ""
 
-#: src/install.rs:2070
+#: src/install.rs:2126
 msgid "can't find package name in packagelist: {}"
 msgstr ""
 
-#: src/install.rs:2142
+#: src/install.rs:2198
 msgid "Signing packages..."
 msgstr ""
 
-#: src/install.rs:2172
+#: src/install.rs:2228
 msgid "{}-{} is up to date -- skipping install"
 msgstr ""
 
@@ -1019,31 +1063,31 @@ msgstr ""
 msgid "aur search failed"
 msgstr ""
 
-#: src/search.rs:285 src/search.rs:338 src/search.rs:410
+#: src/search.rs:291 src/search.rs:344 src/search.rs:416
 msgid "[installed: {}]"
 msgstr ""
 
-#: src/search.rs:287 src/search.rs:340 src/search.rs:412
+#: src/search.rs:293 src/search.rs:346 src/search.rs:418
 msgid "[installed]"
 msgstr ""
 
-#: src/search.rs:332
+#: src/search.rs:338
 msgid "[out-of-date: {}]"
 msgstr ""
 
-#: src/search.rs:347
+#: src/search.rs:353
 msgid "[orphaned]"
 msgstr ""
 
-#: src/search.rs:491
+#: src/search.rs:497
 msgid "no packages match search"
 msgstr ""
 
-#: src/search.rs:529
+#: src/search.rs:535
 msgid "Packages to install (eg: 1 2 3, 1-3):"
 msgstr ""
 
-#: src/search.rs:531
+#: src/search.rs:537
 msgid "Select packages (eg: 1 2 3, 1-3):"
 msgstr ""
 
@@ -1095,31 +1139,31 @@ msgstr ""
 msgid "Packages to exclude (eg: 1 2 3, 1-3):"
 msgstr ""
 
-#: src/util.rs:121
+#: src/util.rs:130
 msgid "[Y/n]:"
 msgstr ""
 
-#: src/util.rs:123
+#: src/util.rs:132
 msgid "[y/N]:"
 msgstr ""
 
-#: src/util.rs:142
+#: src/util.rs:151
 msgid "y"
 msgstr ""
 
-#: src/util.rs:142
+#: src/util.rs:151
 msgid "yes"
 msgstr ""
 
-#: src/util.rs:300
+#: src/util.rs:309
 msgid "Enter a number (default=1): "
 msgstr ""
 
-#: src/util.rs:317
+#: src/util.rs:326
 msgid "invalid number: {}"
 msgstr ""
 
-#: src/util.rs:327
+#: src/util.rs:336
 msgid "invalid value: {n} is not between 1 and {max}"
 msgstr ""
 
@@ -1127,7 +1171,7 @@ msgstr ""
 msgid "There are {} members in group"
 msgstr ""
 
-#: src/resolver.rs:108
+#: src/resolver.rs:106
 msgid "\n"
 "\n"
 "Enter a selection (default=all): "

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -1,7 +1,7 @@
 use crate::args::{PACMAN_FLAGS, PACMAN_GLOBALS};
 use crate::config::{
-    Colors, Config, ConfigEnum, LocalRepos, Mode, Op, Sign, SortMode, YesNoAll, YesNoAllTree,
-    YesNoAsk,
+    parse_release_age, Colors, Config, ConfigEnum, LocalRepos, Mode, Op, Sign, SortMode, YesNoAll,
+    YesNoAllTree, YesNoAsk,
 };
 
 use std::fmt;
@@ -211,6 +211,15 @@ impl Config {
                     .parse()
                     .map_err(|_| anyhow!("option {} must be a number", arg))?
             }
+            Arg::Long("minimumreleaseage") => {
+                self.min_release_age = Some(parse_release_age(value?)?)
+            }
+            Arg::Long("nominimumreleaseage") => self.min_release_age = None,
+            Arg::Long("minimumreleaseageexclude") => {
+                for word in value?.split_whitespace() {
+                    self.min_release_age_exclude_builder.add(Glob::new(word)?);
+                }
+            }
             Arg::Long("sortby") => self.sort_by = ConfigEnum::from_str(argkey, value?)?,
             Arg::Long("searchby") => self.search_by = ConfigEnum::from_str(argkey, value?)?,
             Arg::Long("limit") => self.limit = value?.parse()?,
@@ -417,6 +426,8 @@ fn takes_value(arg: Arg) -> TakesValue {
         Arg::Long("chrootpkgs") => TakesValue::Required,
         Arg::Long("rootchrootpkgs") => TakesValue::Required,
         Arg::Long("completioninterval") => TakesValue::Required,
+        Arg::Long("minimumreleaseage") => TakesValue::Required,
+        Arg::Long("minimumreleaseageexclude") => TakesValue::Required,
         Arg::Long("sortby") => TakesValue::Required,
         Arg::Long("searchby") => TakesValue::Required,
         Arg::Long("limit") => TakesValue::Required,

--- a/src/config.rs
+++ b/src/config.rs
@@ -506,6 +506,12 @@ pub struct Config {
     pub no_warn_builder: GlobSetBuilder,
     pub install_debug: bool,
 
+    pub min_release_age: Option<std::time::Duration>,
+    #[default(GlobSet::empty())]
+    pub min_release_age_exclude: GlobSet,
+    #[default(GlobSetBuilder::new())]
+    pub min_release_age_exclude_builder: GlobSetBuilder,
+
     pub upgrade_menu: bool,
 
     pub makepkg_conf: Option<String>,
@@ -575,7 +581,24 @@ impl Ini for Config {
     }
 }
 
+/// Whether `pkg` ends with any of the configured devel suffixes.
+pub fn matches_devel(suffixes: &[String], pkg: &str) -> bool {
+    suffixes.iter().any(|suff| pkg.ends_with(suff))
+}
+
 impl Config {
+    pub fn is_devel(&self, pkg: &str) -> bool {
+        matches_devel(&self.devel_suffixes, pkg)
+    }
+
+    /// Whether `pkg` is younger than the minimum release age and not exempt
+    /// (devel package or in `min_release_age_exclude`). `now`/`max` are seconds.
+    pub fn is_too_new(&self, pkg: &str, last_modified: i64, now: i64, max: i64) -> bool {
+        !self.is_devel(pkg)
+            && !self.min_release_age_exclude.is_match(pkg)
+            && now - last_modified < max
+    }
+
     pub fn new() -> Result<Self> {
         let cache =
             dirs::cache_dir().ok_or_else(|| anyhow!(tr!("failed to find cache directory")))?;
@@ -826,6 +849,7 @@ then initialise it with:
         }
 
         self.no_warn = self.no_warn_builder.build()?;
+        self.min_release_age_exclude = self.min_release_age_exclude_builder.build()?;
         self.ignore_devel = self.ignore_devel_builder.build()?;
 
         if !self.assume_installed.is_empty() && !self.chroot {
@@ -1136,6 +1160,12 @@ then initialise it with:
                     self.no_warn_builder.add(Glob::new(word)?);
                 }
             }
+            "MinimumReleaseAge" => self.min_release_age = Some(parse_release_age(&value?)?),
+            "MinimumReleaseAgeExclude" => {
+                for word in value?.split_whitespace() {
+                    self.min_release_age_exclude_builder.add(Glob::new(word)?);
+                }
+            }
             "Mode" => {
                 for word in value?.split_whitespace() {
                     self.mode |= word.parse()?;
@@ -1230,6 +1260,32 @@ fn download(filename: &str, event: AnyDownloadEvent, _: &mut ()) {
     }
 }
 
+/// Parse a release-age duration: an integer with an optional unit suffix
+/// (`s`, `m`, `h`, `d`, `w`). A bare number is interpreted as days.
+pub fn parse_release_age(s: &str) -> Result<std::time::Duration> {
+    let s = s.trim();
+    let (num, unit_secs) = match s.as_bytes().last() {
+        Some(b's') => (&s[..s.len() - 1], 1),
+        Some(b'm') => (&s[..s.len() - 1], 60),
+        Some(b'h') => (&s[..s.len() - 1], 60 * 60),
+        Some(b'd') => (&s[..s.len() - 1], 60 * 60 * 24),
+        Some(b'w') => (&s[..s.len() - 1], 60 * 60 * 24 * 7),
+        Some(b'0'..=b'9') => (s, 60 * 60 * 24),
+        _ => bail!(tr!("invalid release age '{}'", s)),
+    };
+
+    let num: u64 = num
+        .trim()
+        .parse()
+        .map_err(|_| anyhow!(tr!("invalid release age '{}'", s)))?;
+
+    let secs = num
+        .checked_mul(unit_secs)
+        .ok_or_else(|| anyhow!(tr!("release age '{}' is too large", s)))?;
+
+    Ok(std::time::Duration::from_secs(secs))
+}
+
 fn log(level: LogLevel, msg: &str, color: &mut Colors) {
     let err = color.error;
     let warn = color.warning;
@@ -1239,5 +1295,32 @@ fn log(level: LogLevel, msg: &str, color: &mut Colors) {
         LogLevel::ERROR => eprint!("{} {}", err.paint("error:"), msg),
         LogLevel::DEBUG if alpm_debug_enabled() => eprint!("debug: <alpm> {}", msg),
         _ => (),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_release_age;
+
+    #[test]
+    fn release_age_units() {
+        let secs = |s| parse_release_age(s).unwrap().as_secs();
+        assert_eq!(secs("7"), 7 * 86400);
+        assert_eq!(secs("7d"), 7 * 86400);
+        assert_eq!(secs("48h"), 48 * 3600);
+        assert_eq!(secs("30m"), 30 * 60);
+        assert_eq!(secs("45s"), 45);
+        assert_eq!(secs("2w"), 2 * 7 * 86400);
+        assert_eq!(secs("0"), 0);
+    }
+
+    #[test]
+    fn release_age_invalid() {
+        assert!(parse_release_age("").is_err());
+        assert!(parse_release_age("7y").is_err());
+        assert!(parse_release_age("abc").is_err());
+        assert!(parse_release_age("-1").is_err());
+        assert!(parse_release_age("d").is_err());
+        assert!(parse_release_age("100000000000000000d").is_err());
     }
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -22,7 +22,7 @@ use crate::keys::check_pgp_keys;
 use crate::pkgbuild::PkgbuildRepo;
 use crate::resolver::{flags, resolver};
 use crate::upgrade::{get_upgrades, Upgrades};
-use crate::util::{ask, repo_aur_pkgs, split_repo_aur_targets};
+use crate::util::{ask, now_secs, repo_aur_pkgs, split_repo_aur_targets};
 use crate::{args, exec, news, print_error, printtr, repo};
 
 use alpm::{Alpm, Depend, Version};
@@ -1092,6 +1092,7 @@ impl Installer {
         let c = config.color;
 
         print_warnings(config, cache, Some(actions));
+        check_release_age(config, actions)?;
 
         if actions.build.is_empty() && actions.install.is_empty() {
             printtr!(" there is nothing to do");
@@ -1328,6 +1329,61 @@ fn print_warnings(config: &Config, cache: &Cache, actions: Option<&Actions>) {
     warnings.orphans.dedup();
 
     warnings.all(config.color, config.cols);
+}
+
+fn human_age(secs: i64) -> String {
+    let secs = secs.max(0);
+    if secs >= 86400 {
+        let n = secs / 86400;
+        tr!("{n} day" | "{n} days" % n)
+    } else if secs >= 3600 {
+        let n = secs / 3600;
+        tr!("{n} hour" | "{n} hours" % n)
+    } else if secs >= 60 {
+        let n = secs / 60;
+        tr!("{n} minute" | "{n} minutes" % n)
+    } else {
+        tr!("{n} second" | "{n} seconds" % secs)
+    }
+}
+
+fn check_release_age(config: &Config, actions: &Actions) -> Result<()> {
+    let Some(max) = config.min_release_age else {
+        return Ok(());
+    };
+
+    let now = now_secs();
+    let max = max.as_secs() as i64;
+
+    let mut too_new = actions
+        .iter_aur_pkgs()
+        .map(|p| &p.pkg)
+        .filter(|p| config.is_too_new(&p.name, p.last_modified, now, max))
+        .map(|p| (p.name.as_str(), now - p.last_modified))
+        .collect::<Vec<_>>();
+
+    if too_new.is_empty() {
+        return Ok(());
+    }
+
+    too_new.sort_unstable();
+    too_new.dedup();
+
+    let list = too_new
+        .iter()
+        .map(|(name, age)| format!("{} ({})", name, tr!("updated {} ago", human_age(*age))))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    bail!(
+        "{}\n    {}",
+        tr!(
+            "the following AUR packages are newer than the minimum release age of {}: {}",
+            human_age(max),
+            list
+        ),
+        tr!("pass --nominimumreleaseage with your operation to override (e.g. paru -Syu --nominimumreleaseage), or add a package to MinimumReleaseAgeExclude")
+    );
 }
 
 fn fmt_stack(want: &DepMissing) -> String {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -19,6 +19,8 @@ impl Mock {
             pkgs: HashMap::new(),
         };
 
+        let now = crate::util::now_secs();
+
         let clone = Path::new(&var("CARGO_MANIFEST_DIR").unwrap()).join("testdata/clone");
 
         for dir in std::fs::read_dir(clone)? {
@@ -46,7 +48,7 @@ impl Mock {
                     out_of_date: None,
                     maintainer: None,
                     first_submitted: 0,
-                    last_modified: 0,
+                    last_modified: now,
                     url_path: "".into(),
                     groups: vec![],
                     depends,

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -73,7 +73,7 @@ pub fn resolver<'a, 'b>(
     let mut resolver = aur_depends::Resolver::new(alpm, cache, raur, flags)
         .pkgbuild_repos(pkgbuild_repos)
         .custom_aur_namespace(Some(config.aur_namespace().to_string()))
-        .is_devel(move |pkg| devel_suffixes.iter().any(|suff| pkg.ends_with(suff)))
+        .is_devel(move |pkg| crate::config::matches_devel(&devel_suffixes, pkg))
         .group_callback(move |groups| {
             let total: usize = groups.iter().map(|g| g.group.packages().len()).sum();
             let mut pkgs = Vec::new();
@@ -98,10 +98,8 @@ pub fn resolver<'a, 'b>(
                     print!("    ");
                 }
 
-                let mut n = 1;
-                for pkg in group.group.packages() {
+                for (n, pkg) in (1..).zip(group.group.packages()) {
                     print!("{}) {}  ", n, pkg.name());
-                    n += 1;
                 }
             }
 
@@ -118,13 +116,11 @@ pub fn resolver<'a, 'b>(
             }
 
             let menu = NumberMenu::new(input.trim());
-            let mut n = 1;
 
-            for pkg in groups.iter().flat_map(|g| g.group.packages()) {
+            for (n, pkg) in (1..).zip(groups.iter().flat_map(|g| g.group.packages())) {
                 if menu.contains(n, "") {
                     pkgs.push(pkg);
                 }
-                n += 1;
             }
 
             pkgs

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use crate::config::SortBy;
 use crate::config::{Config, SortMode};
 use crate::fmt::{color_repo, link_str, print_indent};
-use crate::util::{input, is_arch_repo, NumberMenu};
+use crate::util::{input, is_arch_repo, now_secs, NumberMenu};
 use crate::{info, printtr};
 
 use ansiterm::Style;
@@ -233,7 +233,7 @@ async fn search_aur(config: &Config, targets: &[String]) -> Result<Vec<raur::Pac
     };
 
     match config.sort_by {
-        SortBy::Votes => matches.sort_by(|a, b| b.num_votes.cmp(&a.num_votes)),
+        SortBy::Votes => matches.sort_by_key(|p| std::cmp::Reverse(p.num_votes)),
         SortBy::Popularity => {
             matches.sort_by(|a, b| b.popularity.partial_cmp(&a.popularity).unwrap())
         }
@@ -243,6 +243,12 @@ async fn search_aur(config: &Config, targets: &[String]) -> Result<Vec<raur::Pac
         SortBy::Submitted => matches.sort_by_key(|p| p.first_submitted),
         SortBy::Modified => matches.sort_by_key(|p| p.last_modified),
         _ => (),
+    }
+
+    if let Some(max) = config.min_release_age {
+        let now = now_secs();
+        let max = max.as_secs() as i64;
+        matches.retain(|p| !config.is_too_new(&p.name, p.last_modified, now, max));
     }
 
     if config.limit != 0 {

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,7 @@ use std::io::{stderr, stdin, stdout, BufRead, Write};
 use std::mem::take;
 use std::ops::Range;
 use std::os::fd::{AsFd, OwnedFd};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use alpm::{Package, PackageReason};
 use alpm_utils::depends::{satisfies_dep, satisfies_provide};
@@ -15,6 +16,14 @@ use alpm_utils::{AsTarg, DbListExt, Targ};
 use anyhow::Result;
 use nix::unistd::{dup2_stdin, dup2_stdout};
 use tr::tr;
+
+/// Current time as seconds since the unix epoch.
+pub fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
 
 #[derive(Debug)]
 pub struct NumberMenu<'a> {

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -199,3 +199,74 @@ async fn devel() {
     let a = db.pkg("devel").unwrap();
     assert_eq!(a.version().as_str(), "2-1");
 }
+
+#[tokio::test]
+async fn min_release_age_blocks() {
+    let (tmp, ret) = run(&["-S", "pacaur", "--minimumreleaseage", "30d"])
+        .await
+        .unwrap();
+    assert_ne!(ret, 0);
+    let alpm = alpm(&tmp).unwrap();
+    alpm.localdb().pkg("pacaur").unwrap_err();
+}
+
+#[tokio::test]
+async fn min_release_age_dep_blocks() {
+    let (tmp, ret) = run(&[
+        "-S",
+        "pkg",
+        "--minimumreleaseage",
+        "30d",
+        "--minimumreleaseageexclude",
+        "pkg",
+    ])
+    .await
+    .unwrap();
+    assert_ne!(ret, 0);
+    let alpm = alpm(&tmp).unwrap();
+    alpm.localdb().pkg("pkg").unwrap_err();
+    alpm.localdb().pkg("pacaur").unwrap_err();
+}
+
+#[tokio::test]
+async fn min_release_age_bypass() {
+    let (tmp, ret) = run(&[
+        "-S",
+        "pacaur",
+        "--minimumreleaseage",
+        "30d",
+        "--nominimumreleaseage",
+    ])
+    .await
+    .unwrap();
+    assert_eq!(ret, 0);
+    let alpm = alpm(&tmp).unwrap();
+    alpm.localdb().pkg("pacaur").unwrap();
+}
+
+#[tokio::test]
+async fn min_release_age_exclude() {
+    let (tmp, ret) = run(&[
+        "-S",
+        "pacaur",
+        "--minimumreleaseage",
+        "30d",
+        "--minimumreleaseageexclude",
+        "pacaur",
+    ])
+    .await
+    .unwrap();
+    assert_eq!(ret, 0);
+    let alpm = alpm(&tmp).unwrap();
+    alpm.localdb().pkg("pacaur").unwrap();
+}
+
+#[tokio::test]
+async fn min_release_age_devel_exempt() {
+    let (tmp, ret) = run(&["-S", "auracle-git", "--minimumreleaseage", "30d"])
+        .await
+        .unwrap();
+    assert_eq!(ret, 0);
+    let alpm = alpm(&tmp).unwrap();
+    alpm.localdb().pkg("auracle-git").unwrap();
+}


### PR DESCRIPTION
Supply-chain hijacks of AUR packages are usually caught and reverted within a few days, so installing the very latest version carries the most risk. Let security-conscious users refuse AUR packages whose latest version was published more recently than a configurable age.

`MinimumReleaseAge` (with s/m/h/d/w suffix, bare number means days) blocks install and upgrade when any resolved AUR package, dependencies included, is younger than the threshold, and hides such packages from search. MinimumReleaseAgeExclude and `--nominimumreleaseage` provide opt-outs. Devel packages are exempt since they track upstream commits rather than AUR publish time.

Closes: #1563 